### PR TITLE
CLS Compliance

### DIFF
--- a/Reinforced.Typings/Attributes/TsBaseParamAttribute.cs
+++ b/Reinforced.Typings/Attributes/TsBaseParamAttribute.cs
@@ -13,10 +13,101 @@ namespace Reinforced.Typings.Attributes
         /// <summary>
         ///     Creates instance of TsBaseParamAttribute
         /// </summary>
-        /// <param name="values">Set of TypeScript expressions to be supplied for super() call</param>
-        public TsBaseParamAttribute(params string[] values)
+        /// <param name="value">TypeScript expression to be supplied for super() call</param>
+        public TsBaseParamAttribute(string value)
         {
-            Values = values;
+            Values = new []{ value };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue)
+        {
+            Values = new[] { firstValue, secondValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        /// <param name="fourthValue">TypeScript expression to be supplied for super() call at position 4</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue, string fourthValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue, fourthValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        /// <param name="fourthValue">TypeScript expression to be supplied for super() call at position 4</param>
+        /// <param name="fifthValue">TypeScript expression to be supplied for super() call at position 5</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue, string fourthValue, string fifthValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue, fourthValue, fifthValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        /// <param name="fourthValue">TypeScript expression to be supplied for super() call at position 4</param>
+        /// <param name="fifthValue">TypeScript expression to be supplied for super() call at position 5</param>
+        /// <param name="sixthValue">TypeScript expression to be supplied for super() call at position 6</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue, string fourthValue, string fifthValue, string sixthValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        /// <param name="fourthValue">TypeScript expression to be supplied for super() call at position 4</param>
+        /// <param name="fifthValue">TypeScript expression to be supplied for super() call at position 5</param>
+        /// <param name="sixthValue">TypeScript expression to be supplied for super() call at position 6</param>
+        /// <param name="seventhValue">TypeScript expression to be supplied for super() call at position 7</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue, string fourthValue, string fifthValue, string sixthValue, string seventhValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue };
+        }
+
+        /// <summary>
+        ///     Creates instance of TsBaseParamAttribute
+        /// </summary>
+        /// <param name="firstValue">TypeScript expression to be supplied for super() call at position 1</param>
+        /// <param name="secondValue">TypeScript expression to be supplied for super() call at position 2</param>
+        /// <param name="thirdValue">TypeScript expression to be supplied for super() call at position 3</param>
+        /// <param name="fourthValue">TypeScript expression to be supplied for super() call at position 4</param>
+        /// <param name="fifthValue">TypeScript expression to be supplied for super() call at position 5</param>
+        /// <param name="sixthValue">TypeScript expression to be supplied for super() call at position 6</param>
+        /// <param name="seventhValue">TypeScript expression to be supplied for super() call at position 7</param>
+        /// <param name="eighthValue">TypeScript expression to be supplied for super() call at position 8</param>
+        public TsBaseParamAttribute(string firstValue, string secondValue, string thirdValue, string fourthValue, string fifthValue, string sixthValue, string seventhValue, string eighthValue)
+        {
+            Values = new[] { firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue };
         }
 
         /// <summary>

--- a/Reinforced.Typings/Properties/AssemblyInfo.cs
+++ b/Reinforced.Typings/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -13,6 +14,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright ©  2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+[assembly: CLSCompliant(true)]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/Reinforced.Typings/WriterWrapper.cs
+++ b/Reinforced.Typings/WriterWrapper.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 
 #pragma warning disable 1591
 
@@ -73,6 +74,7 @@ namespace Reinforced.Typings
             _writer.Write(value);
         }
 
+        [CLSCompliantAttribute(false)]
         public void Write(uint value)
         {
             _writer.Write(value);
@@ -83,6 +85,7 @@ namespace Reinforced.Typings
             _writer.Write(value);
         }
 
+        [CLSCompliantAttribute(false)]
         public void Write(ulong value)
         {
             _writer.Write(value);
@@ -179,6 +182,7 @@ namespace Reinforced.Typings
             _writer.WriteLine();
         }
 
+        [CLSCompliantAttribute(false)]
         public void WriteLine(uint value)
         {
             AppendTabs();
@@ -195,6 +199,7 @@ namespace Reinforced.Typings
             _writer.WriteLine();
         }
 
+        [CLSCompliantAttribute(false)]
         public void WriteLine(ulong value)
         {
             AppendTabs();


### PR DESCRIPTION
Makes Reinforced.Typings CLS compliant by marking assembly with appropriate attribute and fixes CLS-related build warnings via attributes and additional constructors. This enables usage of Reinforced.Typings in projects that need to be CLS compliant (e.g. ASP.NET 5 projects which run on Linux)