### PR TITLE
Extension point for type names generation

### DIFF
--- a/Reinforced.Typings/Generators/ClassCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/ClassCodeGenerator.cs
@@ -44,7 +44,7 @@ namespace Reinforced.Typings.Generators
         protected virtual void Export(string declType, Type type, TypeResolver resolver, WriterWrapper sw,
             IAutoexportSwitchAttribute swtch)
         {
-            var name = type.GetName();
+            var name = GetName(type);
 
             Settings.Documentation.WriteDocumentation(type, sw);
             sw.Indent();
@@ -212,6 +212,16 @@ namespace Reinforced.Typings.Generators
                 var generator = resolver.GeneratorFor(m, Settings);
                 generator.Generate(m, resolver, sw);
             }
+        }
+
+        /// <summary>
+        ///     Gets resulting typescript type name of exporting type
+        /// </summary>
+        /// <param name="element">Exporting class</param>
+        /// <returns>Resulting ts type name</returns>
+        protected virtual string GetName(Type element)
+        {
+            return element.GetName();
         }
     }
 }

--- a/Reinforced.Typings/Generators/EnumGenerator.cs
+++ b/Reinforced.Typings/Generators/EnumGenerator.cs
@@ -18,7 +18,7 @@ namespace Reinforced.Typings.Generators
         public virtual void Generate(Type element, TypeResolver resolver, WriterWrapper sw)
         {
             var values = Enum.GetValues(element);
-            var name = element.GetName();
+            var name = GetName(element);
             var fmt = Settings.GetDeclarationFormat(element);
             var fields = element.GetFields().Where(c => !c.IsSpecialName).ToDictionary(c => c.Name, c => c);
 
@@ -54,5 +54,15 @@ namespace Reinforced.Typings.Generators
         ///     Export settings
         /// </summary>
         public ExportSettings Settings { get; set; }
-    }
+
+        /// <summary>
+        ///     Gets resulting typescript type name of exporting type
+        /// </summary>
+        /// <param name="element">Exporting class</param>
+        /// <returns>Resulting ts type name</returns>
+        protected virtual string GetName(Type element)
+        {
+            return element.GetName();
+        }
+	}
 }


### PR DESCRIPTION
Made GetName virtual method in EnumGenerator and ClassCodeGenerator — so, for example, it would be easier to export one C# class twice: once with default naming convention and second time as MVVM model wrapper type.

C# class example: 
```c#
public class Query 
{
    public string Property { get; set; }
}
```

Desired TS output:
```typescript
interface IQuery {
    property: string;
}

interface IKnockoutQuery {
    property: KnockoutObservable<string>;
}
```