### PR TITLE
Removed adding of '.dll' extension during assembly resolves.

### DIFF
--- a/Reinforced.Typings.Cli/Bootstrapper.cs
+++ b/Reinforced.Typings.Cli/Bootstrapper.cs
@@ -233,7 +233,7 @@ namespace Reinforced.Typings.Cli
         {
             if (args.Name.StartsWith("Reinforced.Typings.XmlSerializers")) return Assembly.GetExecutingAssembly();
             AssemblyName nm = new AssemblyName(args.Name);
-            string path = LookupAssemblyPath(nm.Name + ".dll", false);
+            string path = LookupAssemblyPath(nm.Name, false);
             Assembly a = Assembly.LoadFrom(path);
             _totalLoadedAssemblies++;
 #if DEBUG


### PR DESCRIPTION
Removed addding of '.dll' extension inside `CurrentDomainOnAssemblyResolve`, as `LookupAssemblyPath` will handle missing extension by itself. This change fixes resolve of referenced `.exe` assembly. Resolves #44.