### PR TITLE
Adding compilation and build dependencies only if the settings.xml is present

### DIFF
--- a/xmls/Reinforced.Typings.targets
+++ b/xmls/Reinforced.Typings.targets
@@ -1,22 +1,24 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>		
+	<PropertyGroup>
+		<RtSettingsXml Condition="HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)Reinforced.Typings.settings.xml</RtSettingsXml>
+		<RtSettingsXml Condition="!HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)\Reinforced.Typings.settings.xml</RtSettingsXml>
+
+		<RtTargetsPath Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard1.6</RtTargetsPath>
+		<RtTargetsPath Condition=" '$(MSBuildRuntimeType)' != 'Core'">net45</RtTargetsPath>
+	</PropertyGroup>
+    
+	<PropertyGroup Condition="Exists($(RtSettingsXml))" >
 		<TargetsTriggeredByCompilation>
 			$(TargetsTriggeredByCompilation);ReinforcedTypingsGenerate;
 		</TargetsTriggeredByCompilation>		
-		
+
 		<BuildDependsOn>
 			ConditionallyDisableTypeScriptCompilation;
 			ConditionallyShowDisabledWarning;
 			$(BuildDependsOn);
 		</BuildDependsOn>
-        
-        <RtSettingsXml Condition="HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)Reinforced.Typings.settings.xml</RtSettingsXml>
-        <RtSettingsXml Condition="!HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)\Reinforced.Typings.settings.xml</RtSettingsXml>
-        
-        <RtTargetsPath Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard1.6</RtTargetsPath>
-        <RtTargetsPath Condition=" '$(MSBuildRuntimeType)' != 'Core'">net45</RtTargetsPath>
 	</PropertyGroup>
-    
+
     <Import Project="$(RtSettingsXml)" Condition="Exists($(RtSettingsXml))" />
     
 	<UsingTask TaskName="Reinforced.Typings.Integrate.RtCli" AssemblyFile="$(RtTargetsPath)\Reinforced.Typings.Integrate.dll" />


### PR DESCRIPTION
Adds the compilation and build target dependencies only if the settings.xml file is present. Issue details are here - https://github.com/reinforced/Reinforced.Typings/issues/80