### PR TITLE
Convert enum-keyed dictionaries to MappedTypes

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumKeyedDictionary.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumKeyedDictionary.cs
@@ -1,0 +1,33 @@
+﻿using Reinforced.Typings.Fluent;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        [Fact]
+        public void EnumKeyedDictionary()
+        {
+            const string result = @"
+export enum SomeEnum { 
+	One = 0, 
+	Two = 1
+}
+export interface IParametrizedGenericsInterface
+{
+	Bag: { [key in SomeEnum]: string };
+	Bag2: { [key:string]: SomeEnum }[];
+	Bag3: { [key in SomeEnum]: SomeEnum }[][];
+	Bag4: { [key in SomeEnum]: { [key:string]: SomeEnum[][] } };
+}";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment().UseModules());
+                s.ExportAsEnum<SomeEnum>();
+                s.ExportAsInterfaces(
+                    new[] {typeof(IParametrizedGenericsInterface<SomeEnum, string>)},
+                    x => x.WithPublicProperties().WithPublicMethods());
+            }, result);
+        }
+    }
+}

--- a/Reinforced.Typings/Ast/TypeNames/RtDictionaryType.cs
+++ b/Reinforced.Typings/Ast/TypeNames/RtDictionaryType.cs
@@ -21,10 +21,9 @@ namespace Reinforced.Typings.Ast.TypeNames
         /// </summary>
         /// <param name="keySimpleType">Type for dictionary key</param>
         /// <param name="valueSimpleType">Type for disctionary value</param>
-        public RtDictionaryType(string keySimpleType, string valueSimpleType)
+        public RtDictionaryType(RtTypeName keySimpleType, RtTypeName valueSimpleType)
+            : this(keySimpleType, valueSimpleType, false)
         {
-            KeyType = new RtSimpleTypeName(keySimpleType);
-            ValueType = new RtSimpleTypeName(valueSimpleType);
         }
 
         /// <summary>
@@ -32,10 +31,12 @@ namespace Reinforced.Typings.Ast.TypeNames
         /// </summary>
         /// <param name="keySimpleType">Type for dictionary key</param>
         /// <param name="valueSimpleType">Type for disctionary value</param>
-        public RtDictionaryType(RtTypeName keySimpleType, RtTypeName valueSimpleType)
+        /// <param name="isKeyEnum">A flag specifying whether the key is an enum type.</param>
+        public RtDictionaryType(RtTypeName keySimpleType, RtTypeName valueSimpleType, bool isKeyEnum)
         {
             KeyType = keySimpleType;
             ValueType = valueSimpleType;
+            IsKeyEnum = isKeyEnum;
         }
 
         /// <summary>
@@ -47,6 +48,11 @@ namespace Reinforced.Typings.Ast.TypeNames
         /// Type for disctionary value
         /// </summary>
         public RtTypeName ValueType { get; private set; }
+
+        /// <summary>
+        /// A flag indicating whether the key is an enum type, and a mapped type should be generated.
+        /// </summary>
+        public bool IsKeyEnum { get; }
 
         /// <inheritdoc />
         public override IEnumerable<RtNode> Children
@@ -73,7 +79,8 @@ namespace Reinforced.Typings.Ast.TypeNames
         /// <inheritdoc />
         public override string ToString()
         {
-            return String.Format("{{ [key: {0}]: {1} }}", KeyType, ValueType);
+            string keyTypeSpec = IsKeyEnum ? " in " : ":";
+            return $"{{ [key{keyTypeSpec}{KeyType}]: {ValueType} }}";
         }
     }
 }

--- a/Reinforced.Typings/TypeResolver.cs
+++ b/Reinforced.Typings/TypeResolver.cs
@@ -238,13 +238,14 @@ namespace Reinforced.Typings
                     return Cache(t, new RtDictionaryType(AnyType, AnyType));
                 }
                 var gargs = t._GetGenericArguments();
+                bool isKeyEnum = gargs[0].IsEnum;
                 var key = ResolveTypeName(gargs[0]);
-                if (key != NumberType && key != StringType)
+                if (key != NumberType && key != StringType && !isKeyEnum)
                 {
                     _context.Warnings.Add(ErrorMessages.RTW0007_InvalidDictionaryKey.Warn(key, t));
                 }
                 var value = ResolveTypeName(gargs[1]);
-                return Cache(t, new RtDictionaryType(key, value));
+                return Cache(t, new RtDictionaryType(key, value, isKeyEnum));
             }
             if (t.IsNongenericEnumerable())
             {

--- a/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtDictionaryType.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtDictionaryType.cs
@@ -9,7 +9,9 @@ namespace Reinforced.Typings.Visitors.TypeScript
         public override void Visit(RtDictionaryType node)
         {
             if (node == null) return;
-            Write("{ [key:");
+            string keyTypeSpec = node.IsKeyEnum ? " in " : ":";
+            Write("{ [key");
+            Write(keyTypeSpec);
             Visit(node.KeyType);
             Write("]: ");
             Visit(node.ValueType);


### PR DESCRIPTION
```cs
Dictionary<SomeEnum, string> Bag { get; }
```

is converted to

```ts
Bag: { [key in SomeEnum]: string };
```

See description of Mapped Types https://github.com/Microsoft/TypeScript/pull/12114