### PR TITLE
Export unresolved types as 'unknown'

### DIFF
--- a/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
+++ b/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="SpecificCases\SpecificTestCases.ReferencesPart4.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.ReferencesPart5.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.WeirdInheritanceCase.cs" />
+    <Compile Include="SpecificCases\SpecifiicTestCases.UnresolvedToUnknown.cs" />
     <Compile Include="SpecificCases\TestCases.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tokenizing\SimpleTokenizer.cs" />

--- a/Reinforced.Typings.Tests/SpecificCases/SpecifiicTestCases.UnresolvedToUnknown.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecifiicTestCases.UnresolvedToUnknown.cs
@@ -1,0 +1,36 @@
+﻿using Reinforced.Typings.Fluent;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        interface IUnresolvedToUnknownInterface
+        {
+            DateTime? Date { get; }
+        }
+
+        [Fact]
+        public void UnresolvedToUnknown()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface IUnresolvedToUnknownInterface
+	{
+		Date: unknown;
+	}
+}";
+
+            AssertConfiguration(s =>
+            {
+                s.Global(c => c.UnresolvedToUnknown(true));
+                s.ExportAsInterface<IUnresolvedToUnknownInterface>().WithPublicProperties();
+            }, result);
+        }
+    }
+}

--- a/Reinforced.Typings/Attributes/TsGlobalAttribute.cs
+++ b/Reinforced.Typings/Attributes/TsGlobalAttribute.cs
@@ -93,6 +93,11 @@ namespace Reinforced.Typings.Attributes
         public bool AutoOptionalProperties { get; set; }
 
         /// <summary>
+        /// When true unresolved types will be exported as 'unknown', otherwise as 'any'
+        /// </summary>
+        public bool UnresolvedToUnknown { get; set; }
+
+        /// <summary>
         /// Default constructor for TsGlobal attribute
         /// </summary>
         public TsGlobalAttribute()

--- a/Reinforced.Typings/Exceptions/ErrorMessages.cs
+++ b/Reinforced.Typings/Exceptions/ErrorMessages.cs
@@ -114,7 +114,7 @@ namespace Reinforced.Typings.Exceptions
         /// <summary>
         /// Could not find suitable TypeScript type for {0}. 'any' assumed.
         /// </summary>
-        public static readonly ErrorMessage RTW0003_TypeUnknown = new ErrorMessage(0003, "Could not find suitable TypeScript type for {0}. 'any' assumed.", "Type resolvation");
+        public static readonly ErrorMessage RTW0003_TypeUnknown = new ErrorMessage(0003, "Could not find suitable TypeScript type for {0}. '{1}' assumed.", "Type resolvation");
 
         /// <summary>
         /// No suitable base constructor found for {0}. Generating 'super' call with all nulls.

--- a/Reinforced.Typings/Fluent/GlobalConfigurationBuilder.cs
+++ b/Reinforced.Typings/Fluent/GlobalConfigurationBuilder.cs
@@ -187,10 +187,10 @@ namespace Reinforced.Typings.Fluent
         /// When true unresolved types will be exported as 'unknown', otherwise as 'any'
         /// </summary>
         /// <param name="builder">Conf builder</param>
-        /// <param name="unresolvedToUnkown">True to export unresolved types as 'unknown', false to export as 'any'</param>
-        public static GlobalConfigurationBuilder UnresolvedToUnknown(this GlobalConfigurationBuilder builder, bool unresolvedToUnkown = false)
+        /// <param name="unresolvedToUnknown">True to export unresolved types as 'unknown', false to export as 'any'</param>
+        public static GlobalConfigurationBuilder UnresolvedToUnknown(this GlobalConfigurationBuilder builder, bool unresolvedToUnknown = false)
         {
-            builder.Parameters.UnresolvedToUnknown = unresolvedToUnkown;
+            builder.Parameters.UnresolvedToUnknown = unresolvedToUnknown;
             return builder;
         }
 

--- a/Reinforced.Typings/Fluent/GlobalConfigurationBuilder.cs
+++ b/Reinforced.Typings/Fluent/GlobalConfigurationBuilder.cs
@@ -183,6 +183,17 @@ namespace Reinforced.Typings.Fluent
             return builder;
         }
 
+        /// <summary>
+        /// When true unresolved types will be exported as 'unknown', otherwise as 'any'
+        /// </summary>
+        /// <param name="builder">Conf builder</param>
+        /// <param name="unresolvedToUnkown">True to export unresolved types as 'unknown', false to export as 'any'</param>
+        public static GlobalConfigurationBuilder UnresolvedToUnknown(this GlobalConfigurationBuilder builder, bool unresolvedToUnkown = false)
+        {
+            builder.Parameters.UnresolvedToUnknown = unresolvedToUnkown;
+            return builder;
+        }
+
         //{
         //    bool strict = true)
         //public static GlobalConfigurationBuilder StrictNullChecks(this GlobalConfigurationBuilder builder,

--- a/Reinforced.Typings/GlobalParameters.cs
+++ b/Reinforced.Typings/GlobalParameters.cs
@@ -228,6 +228,17 @@ namespace Reinforced.Typings
             }
         }
 
-        
+        /// <summary>
+        /// When true unresolved types will be exported as 'unknown', otherwise as 'any'
+        /// </summary>
+        public bool UnresolvedToUnknown
+        {
+            get { return _attr.UnresolvedToUnknown; }
+            set
+            {
+                if (_isLocked) return;
+                _attr.UnresolvedToUnknown = value;
+            }
+        }
     }
 }

--- a/Reinforced.Typings/TypeResolver.cs
+++ b/Reinforced.Typings/TypeResolver.cs
@@ -17,6 +17,7 @@ namespace Reinforced.Typings
         private static readonly RtSimpleTypeName AnyType = new RtSimpleTypeName("any");
         private static readonly RtSimpleTypeName NumberType = new RtSimpleTypeName("number");
         private static readonly RtSimpleTypeName StringType = new RtSimpleTypeName("string");
+        private static readonly RtSimpleTypeName UnknownType = new RtSimpleTypeName("unknown");
 
         /// <summary>
         /// Hash set of all numeric types
@@ -90,6 +91,8 @@ namespace Reinforced.Typings
             {typeof (decimal), NumberType}
         };
 
+        private readonly RtSimpleTypeName _anyOrUnknown;
+
         private ExportContext Context
         {
             get { return _file.Context; }
@@ -103,6 +106,10 @@ namespace Reinforced.Typings
         internal TypeResolver(ExportedFile file)
         {
             _file = file;
+
+            _anyOrUnknown = _file.Context.Global.UnresolvedToUnknown
+                        ? UnknownType
+                        : AnyType;            
         }
 
         private RtTypeName[] GetConcreteGenericArguments(Type t, Dictionary<string, RtTypeName> materializedGenerics = null)
@@ -289,7 +296,7 @@ namespace Reinforced.Typings
             {
                 var def = t.GetGenericTypeDefinition();
                 var tsFriendly = ResolveTypeNameInner(def) as RtSimpleTypeName;
-                if (tsFriendly != null && tsFriendly != AnyType)
+                if (tsFriendly != null && tsFriendly != AnyType && tsFriendly != UnknownType)
                 {
                     var parametrized = new RtSimpleTypeName(tsFriendly.TypeName,
                         t._GetGenericArguments().Select(c => ResolveTypeNameInner(c, null)).ToArray())
@@ -306,9 +313,9 @@ namespace Reinforced.Typings
                 return Cache(t, NumberType);
             }
 
-            Context.Warnings.Add(ErrorMessages.RTW0003_TypeUnknown.Warn(t.FullName));
+            Context.Warnings.Add(ErrorMessages.RTW0003_TypeUnknown.Warn(t.FullName, _anyOrUnknown));
 
-            return Cache(t, AnyType);
+            return Cache(t, _anyOrUnknown);
         }
 
         private RtDelegateType ConstructFunctionType(MethodInfo methodInfo, Dictionary<string, RtTypeName> materializedGenerics = null)


### PR DESCRIPTION
This PR adds a Global Configuration Parameter which when set to true will export unresolved types as 'unknown' instead of the current behaviour of 'any'. The default value is false.

The intention is is to increase safety by preventing unintended 'any' types from being generated.