### PR TITLE
Add a generator for custom code

### DIFF
--- a/Reinforced.Typings/Ast/IRtVisitor.cs
+++ b/Reinforced.Typings/Ast/IRtVisitor.cs
@@ -31,6 +31,7 @@ namespace Reinforced.Typings.Ast
         T Visit(RtDecorator node);
         T Visit(RtReference node);
         T Visit(RtTuple node);
+        T Visit(RtContainer node);
     }
 
     /// <summary>
@@ -59,5 +60,6 @@ namespace Reinforced.Typings.Ast
         void Visit(RtDecorator node);
         void Visit(RtReference node);
         void Visit(RtTuple node);
+        void Visit(RtContainer node);
     }
 }

--- a/Reinforced.Typings/Ast/RtContainer.cs
+++ b/Reinforced.Typings/Ast/RtContainer.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+
+namespace Reinforced.Typings.Ast
+{
+    /// <summary>
+    /// AST node for node collections
+    /// </summary>
+    public class RtContainer:RtNode
+    {
+        private readonly HashSet<RtNode> _children = new HashSet<RtNode>();
+
+        public override IEnumerable<RtNode> Children => _children;
+
+        public void Add(RtNode node)
+        {
+            if (node == null) throw new ArgumentNullException(nameof(node));
+            _children.Add(node);
+        }
+
+        public void AddRange(IEnumerable<RtNode> nodes)
+        {
+            if (nodes == null) throw new ArgumentNullException(nameof(nodes));
+            foreach (RtNode node in nodes)
+            {
+                _children.Add(node);
+            }
+        }
+
+        public override void Accept(IRtVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        public override void Accept<T>(IRtVisitor<T> visitor)
+        {
+            visitor.Visit(this);
+        }
+    }
+}

--- a/Reinforced.Typings/ExportContext/ExportContext.Initialization.cs
+++ b/Reinforced.Typings/ExportContext/ExportContext.Initialization.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Reinforced.Typings.Attributes;
 using Reinforced.Typings.Fluent;
+using Reinforced.Typings.Generators;
 using Reinforced.Typings.ReferencesInspection;
 using Reinforced.Typings.Xmldoc;
 // ReSharper disable CheckNamespace
@@ -90,11 +92,24 @@ namespace Reinforced.Typings
                     Project.AddFileSeparationSettings(type);
                 }
             }
-            if (!Hierarchical) TypesToFilesMap = new Dictionary<string, IEnumerable<Type>>();
-            else TypesToFilesMap =
-                allTypes.Where(d => Project.Blueprint(d).ThirdParty == null)
-                    .GroupBy(c => GetPathForType(c, stripExtension: false))
-                    .ToDictionary(c => c.Key, c => c.AsEnumerable());
+
+            if (!Hierarchical)
+            {
+                TypesToFilesMap = new Dictionary<string, IEnumerable<Type>>();
+                CustomGeneratorsToFilesMap = new Dictionary<string, IEnumerable<ICustomCodeGenerator>>();
+            }
+            else 
+            {
+                TypesToFilesMap =
+                    allTypes
+                        .Where(d => Project.Blueprint(d).ThirdParty == null)
+                        .GroupBy(c => GetPathForType(c, stripExtension: false))
+                        .ToDictionary(c => c.Key, c => c.AsEnumerable());
+                CustomGeneratorsToFilesMap =
+                    CustomBuilders
+                        .GroupBy(b => Path.Combine(TargetDirectory,b.FileName))
+                        .ToDictionary(g => g.Key, g => g.Select(b => b.Generator));
+            }
 
 
         }

--- a/Reinforced.Typings/ExportContext/ExportContext.Readonly.cs
+++ b/Reinforced.Typings/ExportContext/ExportContext.Readonly.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 using Reinforced.Typings.Exceptions;
-using Reinforced.Typings.ReferencesInspection;
+using Reinforced.Typings.Fluent;
 using Reinforced.Typings.Xmldoc;
 // ReSharper disable CheckNamespace
 namespace Reinforced.Typings
@@ -69,6 +69,10 @@ namespace Reinforced.Typings
         public ProjectBlueprint Project { get; private set; }
 
        
+        /// <summary>
+        /// Custom code builders
+        /// </summary>
+        internal List<CustomExportBuilder> CustomBuilders { get; private set; }
 
     }
 }

--- a/Reinforced.Typings/ExportContext/ExportContext.cs
+++ b/Reinforced.Typings/ExportContext/ExportContext.cs
@@ -2,6 +2,8 @@
 using System.Collections.Generic;
 using System.Reflection;
 using Reinforced.Typings.Exceptions;
+using Reinforced.Typings.Fluent;
+using Reinforced.Typings.Generators;
 
 namespace Reinforced.Typings
 {
@@ -25,6 +27,8 @@ namespace Reinforced.Typings
             SourceAssemblies = sourceAssemblies;
             Location = new Location(this);
             Project = new ProjectBlueprint();
+            CustomBuilders = new List<CustomExportBuilder>();
+            CustomGeneratorsToFilesMap = new Dictionary<string, IEnumerable<ICustomCodeGenerator>>();
         }
 
         /// <summary>
@@ -34,5 +38,6 @@ namespace Reinforced.Typings
         internal bool SpecialCase { get; set; }
 
         internal Dictionary<string, IEnumerable<Type>> TypesToFilesMap { get; private set; }
+        internal Dictionary<string, IEnumerable<ICustomCodeGenerator>> CustomGeneratorsToFilesMap { get; private set; }
     }
 }

--- a/Reinforced.Typings/ExportedFile.cs
+++ b/Reinforced.Typings/ExportedFile.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Text;
 using Reinforced.Typings.Ast;
 using Reinforced.Typings.Ast.Dependency;
+using Reinforced.Typings.Generators;
 using Reinforced.Typings.ReferencesInspection;
 
 namespace Reinforced.Typings
@@ -21,10 +22,11 @@ namespace Reinforced.Typings
         }
 
         /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
-        internal ExportedFile(HashSet<Type> typesToExport, string fileName, InspectedReferences references, ExportContext context)
+        internal ExportedFile(HashSet<Type> typesToExport, List<ICustomCodeGenerator> customCodeGenerators, string fileName, InspectedReferences references, ExportContext context)
         {
             _context = context;
             TypesToExport = typesToExport;
+            CustomGenerators = customCodeGenerators;
             FileName = fileName;
             AllTypesIsSingleFile = !_context.Hierarchical;
             References = references;
@@ -80,6 +82,11 @@ namespace Reinforced.Typings
         {
             get { return _refinedImports ?? References.Imports; }
         }
+
+        /// <summary>
+        /// List of custom code generators
+        /// </summary>
+        public List<ICustomCodeGenerator> CustomGenerators { get; set; }
 
         internal void ApplyReferenceProcessor(ReferenceProcessorBase refProcessor = null)
         {

--- a/Reinforced.Typings/Fluent/TypeBuilders/CustomExportBuilder.cs
+++ b/Reinforced.Typings/Fluent/TypeBuilders/CustomExportBuilder.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Reinforced.Typings.Generators;
+
+// ReSharper disable CheckNamespace
+
+namespace Reinforced.Typings.Fluent
+{
+    /// <summary>
+    /// Fluent export configuration builder for class
+    /// </summary>
+    public class CustomExportBuilder
+    {
+        private string _fileName;
+
+        internal CustomExportBuilder(ICustomCodeGenerator generator)
+        {
+            Generator = generator;
+        }
+        internal ICustomCodeGenerator Generator { get; }
+
+        internal Type GeneratorType { get; set; }
+
+        internal string FileName
+        {
+            get => string.IsNullOrWhiteSpace(_fileName) ? Generator.GetType().Name : _fileName;
+            set => _fileName = value;
+        }
+
+        public void WithFileName(string fileName)
+        {
+            FileName = fileName;
+        }
+    }
+
+    /// <summary>
+    /// Set of extensions for type export configuration
+    /// </summary>
+    public static partial class TypeConfigurationBuilderExtensions
+    {
+        /// <summary>
+        ///     Includes specified <see cref="ICustomCodeGenerator"/> in generated TypeScript
+        /// </summary>
+        /// <typeparam name="T"><see cref="ICustomCodeGenerator"/> to include</typeparam>
+        /// <param name="builder">Configuration builder</param>
+        /// <returns>Fluent</returns>
+        public static CustomExportBuilder ExportCustomCode<T>(this ConfigurationBuilder builder) where T : ICustomCodeGenerator, new()
+        {
+
+            foreach (CustomExportBuilder customBuilder in builder.Context.CustomBuilders)
+            {
+                if (customBuilder.GeneratorType == typeof(T))
+                    return customBuilder;
+            }
+
+            var conf = new CustomExportBuilder(new T()) {GeneratorType = typeof(T)};
+            builder.Context.CustomBuilders.Add(conf);
+            return conf;
+        }
+
+        /// <summary>
+        ///     Includes specified <see cref="ICustomCodeGenerator"/> in generated TypeScript
+        /// </summary>
+        /// <param name="builder">Configuration builder</param>
+        /// <param name="generator"><see cref="ICustomCodeGenerator"/> to include</param>
+        /// <returns>Fluent</returns>
+        public static CustomExportBuilder ExportCustomCode(this ConfigurationBuilder builder, ICustomCodeGenerator generator)
+        {
+
+            foreach (CustomExportBuilder customBuilder in builder.Context.CustomBuilders)
+            {
+                if (customBuilder.Generator == generator)
+                    return customBuilder;
+            }
+            
+            var conf = new CustomExportBuilder(generator);
+            builder.Context.CustomBuilders.Add(conf);
+            return conf;
+        }
+
+       
+    }
+}

--- a/Reinforced.Typings/Generators/ICustomCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/ICustomCodeGenerator.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Reinforced.Typings.Ast;
+
+namespace Reinforced.Typings.Generators
+{
+    public interface ICustomCodeGenerator
+    {
+        IEnumerable<RtNode> Generate();
+    }
+}

--- a/Reinforced.Typings/TsExporter.cs
+++ b/Reinforced.Typings/TsExporter.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using Reinforced.Typings.Ast;
-using Reinforced.Typings.Fluent;
 using Reinforced.Typings.ReferencesInspection;
 
 namespace Reinforced.Typings
@@ -99,12 +98,11 @@ namespace Reinforced.Typings
             }
             else
             {
-                foreach (var kv in _context.TypesToFilesMap)
+                foreach (var fileName in _context.TypesToFilesMap.Keys.Union(_context.CustomGeneratorsToFilesMap.Keys).Distinct())
                 {
-                    var path = kv.Key;
-                    var file = ExportTypes(kv.Key);
+                    var file = ExportTypes(fileName);
                     file.ApplyReferenceProcessor(refProc);
-                    _context.FileOperations.Export(path, file);
+                    _context.FileOperations.Export(fileName, file);
                 }
             }
 

--- a/Reinforced.Typings/Visitors/TextExportingVisitor.cs
+++ b/Reinforced.Typings/Visitors/TextExportingVisitor.cs
@@ -1,6 +1,8 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
-using Reinforced.Typings.Ast.Dependency;
+using Reinforced.Typings.Ast;
 
 #pragma warning disable 1591
 
@@ -115,6 +117,11 @@ namespace Reinforced.Typings.Visitors
             foreach (var fileNamespace in file.Namespaces)
             {
                 Visit(fileNamespace);
+            }
+
+            foreach (var rtNode in file.CustomGenerators.SelectMany(g => g.Generate() ?? new List<RtNode>()))
+            {
+                Visit(rtNode);
             }
         }
     }

--- a/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtContainer.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtContainer.cs
@@ -1,0 +1,17 @@
+﻿using Reinforced.Typings.Ast;
+#pragma warning disable 1591
+namespace Reinforced.Typings.Visitors.TypeScript
+{
+    partial class TypeScriptExportVisitor
+    {
+        public override void Visit(RtContainer node)
+        {
+            if (node == null) return;
+            foreach (RtNode child in node.Children)
+            {
+                Visit(child);
+            }
+        }
+
+    }
+}

--- a/Reinforced.Typings/Visitors/TypedVisitorBase.cs
+++ b/Reinforced.Typings/Visitors/TypedVisitorBase.cs
@@ -29,6 +29,7 @@ namespace Reinforced.Typings.Visitors
             if (node is RtDecorator) return Visit((RtDecorator)node);
             if (node is RtReference) return Visit((RtReference)node);
             if (node is RtTuple) return Visit((RtTuple)node);
+            if (node is RtContainer) return Visit((RtContainer)node);
             throw new Exception("Unknown node passed");
         }
 
@@ -53,6 +54,7 @@ namespace Reinforced.Typings.Visitors
         public abstract T Visit(RtReference node);
         
         public abstract T Visit(RtTuple node);
+        public abstract T Visit(RtContainer node);
         public abstract T VisitFile(ExportedFile file);
     }
 }

--- a/Reinforced.Typings/Visitors/VisitorBase.cs
+++ b/Reinforced.Typings/Visitors/VisitorBase.cs
@@ -30,6 +30,7 @@ namespace Reinforced.Typings.Visitors
             if (node is RtDecorator) { Visit((RtDecorator)node); return; }
             if (node is RtReference) { Visit((RtReference)node); return; }
             if (node is RtTuple) { Visit((RtTuple)node); return; }
+            if (node is RtContainer) { Visit((RtContainer)node); return; }
 
             throw new Exception("Unknown node passed");
         }
@@ -54,6 +55,7 @@ namespace Reinforced.Typings.Visitors
         public abstract void Visit(RtDecorator node);
         public abstract void Visit(RtReference node);
         public abstract void Visit(RtTuple node);
+        public abstract void Visit(RtContainer node);
         public abstract void VisitFile(ExportedFile file);
     }
 }


### PR DESCRIPTION
Adds custom code generator that returns a list of RtNodes. This is helpful when you need to generate classes/interfaces that depend on C# types but have specific characteristics in TypeScript that are not needed on the server side.

These generators can generate pretty much every type of TS. Classes/Interface like the library is already able to do but also objects that are generated from these generated types.

### Usage Example: Localization
I have different C# DTO classes that represent form data and are used to automatically generate forms via TypeScript. The labels for the form fields are localizable.

```csharp
class Login
{
    public string Username { get; set; }
    public string Password { get; set; }
    public bool RememberMe { get; set; }
}

public class Register
{
    public string Username { get; set; }
    public string Password { get; set; }
    public string PasswordRepeat { get; set; }
}
```
A CustomCodeGenerator then generates a TS interface that combines localization fields for all properties of the two classes. This interface is not needed at all on the server and it would need to be maintained manually whenever one of the C# form classes is changed.

```typescript
interface ILocales {
    forms: IFormLocales
}

interface IFormLocales {
    username: string;
    password: string;
    rememberMe: string;
    passwordRepeat: string;
}
```

I use a localization framework that is initialized with an IFormLocales object and when I need a localized string I pass the path to the property of the object (e.g. translate("forms.userName")). To avoid typing the string every time my custom generator also generates a helper object for this:

```typescript
export const locales: ILocales = {
    forms: {
        password: "Password",
        passwordRepeat: "Repeat Password",
        rememberMe: "Remember Me",
        username: "Username"
    }
};
```