### PR TITLE
Support "net48" TargetFramework.

### DIFF
--- a/Reinforced.Typings.Integrate/RtCli.cs
+++ b/Reinforced.Typings.Integrate/RtCli.cs
@@ -152,6 +152,7 @@ namespace Reinforced.Typings.Integrate
 
             if (TargetFramework.StartsWith("net46")) return "net461";
             if (TargetFramework.StartsWith("net47")) return "net461";
+            if (TargetFramework.StartsWith("net48")) return "net461";
             return TargetFramework;
         }
 


### PR DESCRIPTION
Hi I'm converting .net 4.8 project to new [SDK-style csproj](https://docs.microsoft.com/en-gb/visualstudio/msbuild/how-to-use-project-sdk?view=vs-2019) so my .csproj look like that now (simplified):
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net48</TargetFramework>
  </PropertyGroup>
  <ItemGroup>
    <Content Include="Reinforced.Typings.settings.xml" />
  </ItemGroup>
</Project>
```
But now I get this error:
```
Error	MSB6004	The specified task executable location "C:\Users\Mariusz\.nuget\packages\reinforced.typings\1.5.3\tools\net48\rtcli.exe" is invalid.	Analyx.CWX.InternalApi	C:\Users\Mariusz\.nuget\packages\reinforced.typings\1.5.3\build\Reinforced.Typings.targets	59	
```

This should fix the error.