### PR TITLE
Support inheritdoc in XML documentation

### DIFF
--- a/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
+++ b/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="SpecificCases\SpecificTestCases.GenericsExport2.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.GenericsExport.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.HierarchyFlattening4.cs" />
+    <Compile Include="SpecificCases\SpecificTestCases.InheritDoc.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.InvalidFlattenOrder.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.HierarchyFlattening3.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.HierarchyFlattening2.cs" />

--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.InheritDoc.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.InheritDoc.cs
@@ -1,0 +1,237 @@
+using Reinforced.Typings.Fluent;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+  /// <summary>
+  /// Some documentation for interface.
+  /// </summary>
+  public interface ISomeInterfaceWithDocs
+  {
+    /// <summary>
+    /// Some documentation for interface property.
+    /// </summary>
+    string InterfaceProp { get; set; }
+
+    /// <summary>
+    /// Some documentation for interface method.
+    /// </summary>
+    void InterfaceMethod();
+  }
+
+  /// <inheritdoc/>
+  public interface ISomeInterfaceWithInheritDoc : ISomeInterfaceWithDocs
+  {
+    // TODO: Test with inheritdoc + cref, makes no sense without cref
+  }
+
+  /// <inheritdoc/>
+  public class SomeClassWithInterfaceInheritDoc : ISomeInterfaceWithDocs
+  {
+    /// <inheritdoc/>
+    public string InterfaceProp { get; set; }
+
+    /// <inheritdoc/>
+    public void InterfaceMethod() {}
+  }
+
+  /// <summary>
+  /// Some documentation for class.
+  /// </summary>
+  public class SomeClassWithDocs
+  {
+    /// <summary>
+    /// Some documentation for constructor.
+    /// </summary>
+    public SomeClassWithDocs() {}
+
+    /// <summary>
+    /// Some documentation for property.
+    /// </summary>
+    public virtual string SomeProp { get; set; }
+
+    /// <summary>
+    /// Some documentation for method.
+    /// </summary>
+    public virtual void SomeMethod() {}
+  }
+
+  /// <inheritdoc/>
+  public class SomeClassWithInheritDoc : SomeClassWithDocs
+  {
+    /// <inheritdoc/>
+    public SomeClassWithInheritDoc() {}
+
+    /// <inheritdoc/>
+    public override string SomeProp { get; set; }
+
+    /// <inheritdoc/>
+    public override void SomeMethod() {}
+  }
+
+  /// <inheritdoc cref="SomeClassWithDocs"/>
+  public class SomeClassWithInheritDocCref
+  {
+    /// <inheritdoc cref="SomeClassWithDocs()"/>
+    public SomeClassWithInheritDocCref() {}
+
+    /// <inheritdoc cref="SomeClassWithDocs.SomeProp"/>
+    public virtual string AnotherProp { get; set; }
+
+    /// <inheritdoc cref="SomeClassWithDocs.SomeMethod"/>
+    public virtual void AnotherMethod() {}
+  }
+
+  public partial class SpecificTestCases
+  {
+    [Fact]
+    public void InheritDocInterface()
+    {
+      const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	/**
+	* @inheritdoc
+	*/
+	export interface ISomeInterfaceWithInheritDoc
+	{
+	}
+}
+";
+
+      AssertConfiguration(
+        s =>
+        {
+          s.Global(a => a.DontWriteWarningComment().GenerateDocumentation());
+          s.TryLookupDocumentationForAssembly(typeof(SpecificTestCases).Assembly);
+
+          s.ExportAsInterface<ISomeInterfaceWithInheritDoc>()
+           .WithPublicProperties().WithPublicMethods();
+        }, result, exp =>
+        {
+          var doc = exp.Context.Documentation.GetDocumentationMember(typeof(ISomeInterfaceWithInheritDoc));
+          Assert.NotNull(doc);
+        }, compareComments: true);
+    }
+
+    [Fact]
+    public void InheritDocInterfaceToClass()
+    {
+      const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	/**
+	* @inheritdoc
+	*/
+	export class SomeClassWithInterfaceInheritDoc
+	{ 
+		/**
+		* @inheritdoc
+		*/
+		public InterfaceProp: string;
+		/**
+		* @inheritdoc
+		*/
+		public InterfaceMethod() : void { } 
+	}
+}
+";
+
+      AssertConfiguration(
+        s =>
+        {
+          s.Global(a => a.DontWriteWarningComment().GenerateDocumentation());
+          s.TryLookupDocumentationForAssembly(typeof(SpecificTestCases).Assembly);
+
+          s.ExportAsClass<SomeClassWithInterfaceInheritDoc>()
+           .WithPublicProperties()
+           .WithPublicMethods();
+        }, result, exp =>
+        {
+          var doc = exp.Context.Documentation.GetDocumentationMember(typeof(SomeClassWithInterfaceInheritDoc));
+          Assert.NotNull(doc);
+        }, compareComments: true);
+    }
+
+    [Fact]
+    public void InheritDocClass()
+    {
+      const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	/**
+	* @inheritdoc
+	*/
+	export class SomeClassWithInheritDoc
+	{
+		/**
+		* @inheritdoc
+		*/
+		constructor () { } 
+		/**
+		* @inheritdoc
+		*/
+		public SomeProp: string;
+		/**
+		* @inheritdoc
+		*/
+		public SomeMethod() : void { } 
+	}
+}
+";
+
+      AssertConfiguration(
+        s =>
+        {
+          s.Global(a => a.DontWriteWarningComment().GenerateDocumentation());
+          s.TryLookupDocumentationForAssembly(typeof(SpecificTestCases).Assembly);
+
+          s.ExportAsClass<SomeClassWithInheritDoc>()
+           .WithConstructor()
+           .WithPublicProperties()
+           .WithPublicMethods();
+        }, result, exp =>
+        {
+          var doc = exp.Context.Documentation.GetDocumentationMember(typeof(SomeClassWithInheritDoc));
+          Assert.NotNull(doc);
+        }, compareComments: true);
+    }
+
+    /// <summary>
+    /// TODO: This test fails because cref handling isn't implemented
+    /// </summary>
+    [Fact]
+    public void InheritDocCref()
+    {
+      const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	/** Some documentation for class. */
+	export class SomeClassWithInheritDocCref
+	{
+		/** Some documentation for constructor. */
+		constructor () { }
+
+		/** Some documentation for property. */
+		public AnotherProp: string; 
+
+		/** Some documentation for method. */
+		public AnotherMethod() : void { }  
+	}
+}
+";
+
+      AssertConfiguration(
+        s =>
+        {
+          s.Global(a => a.DontWriteWarningComment().GenerateDocumentation());
+          s.TryLookupDocumentationForAssembly(typeof(SpecificTestCases).Assembly);
+
+          s.ExportAsClass<SomeClassWithInheritDocCref>()
+           .WithConstructor()
+           .WithPublicProperties()
+           .WithPublicMethods();
+        }, result, exp =>
+        {
+          var doc = exp.Context.Documentation.GetDocumentationMember(typeof(SomeClassWithInheritDocCref));
+          Assert.NotNull(doc);
+        }, compareComments: true);
+    }
+  }
+}

--- a/Reinforced.Typings.Tests/TypeNameEqualityComparer.cs
+++ b/Reinforced.Typings.Tests/TypeNameEqualityComparer.cs
@@ -20,7 +20,9 @@ namespace Reinforced.Typings.Tests
         private bool CompareSimple(RtSimpleTypeName x, RtSimpleTypeName y)
         {
             if (x.TypeName != y.TypeName) return false;
-            if (x.Prefix != y.Prefix) return false;
+
+            if ((x.HasPrefix || y.HasPrefix) && x.Prefix != y.Prefix) return false;
+
             if (x.GenericArguments.Length != y.GenericArguments.Length) return false;
 
             for (int i = 0; i < x.GenericArguments.Length; i++)

--- a/Reinforced.Typings.Tests/TypeNameEqualityComparer.cs
+++ b/Reinforced.Typings.Tests/TypeNameEqualityComparer.cs
@@ -20,9 +20,7 @@ namespace Reinforced.Typings.Tests
         private bool CompareSimple(RtSimpleTypeName x, RtSimpleTypeName y)
         {
             if (x.TypeName != y.TypeName) return false;
-
             if ((x.HasPrefix || y.HasPrefix) && x.Prefix != y.Prefix) return false;
-
             if (x.GenericArguments.Length != y.GenericArguments.Length) return false;
 
             for (int i = 0; i < x.GenericArguments.Length; i++)

--- a/Reinforced.Typings/Ast/RtJsdocNode.cs
+++ b/Reinforced.Typings/Ast/RtJsdocNode.cs
@@ -43,5 +43,11 @@ namespace Reinforced.Typings.Ast
         {
             visitor.Visit(this);
         }
+
+        /// <summary>
+        /// Adds an additional JSDOC documentation tag.
+        /// </summary>
+        public void AddTag(DocTag tag, string value = null) =>
+            TagToDescription.Add(new Tuple<DocTag, string>(tag, value));
     }
 }

--- a/Reinforced.Typings/Ast/TypeNames/RtSimpleTypeName.cs
+++ b/Reinforced.Typings/Ast/TypeNames/RtSimpleTypeName.cs
@@ -51,6 +51,11 @@ namespace Reinforced.Typings.Ast.TypeNames
         public string Prefix { get; set; }
 
         /// <summary>
+        /// <c>true</c> if the <see cref="Prefix"/> is not empty.
+        /// </summary>
+        public bool HasPrefix => !string.IsNullOrEmpty(Prefix);
+
+        /// <summary>
         /// Type name
         /// </summary>
         public string TypeName { get; private set; }
@@ -86,7 +91,7 @@ namespace Reinforced.Typings.Ast.TypeNames
         {
             string generics = _genericArguments.Length > 0 ? "<" + String.Join(",", _genericArguments.AsEnumerable()) + ">" : null;
             var result = String.Concat(TypeName, generics);
-            if (!string.IsNullOrEmpty(Prefix))
+            if (HasPrefix)
             {
                 result =  Prefix + "." + result;
             }

--- a/Reinforced.Typings/Generators/ClassAndInterfaceGeneratorBase.cs
+++ b/Reinforced.Typings/Generators/ClassAndInterfaceGeneratorBase.cs
@@ -36,6 +36,7 @@ namespace Reinforced.Typings.Generators
             if (doc != null)
             {
                 RtJsdocNode docNode = new RtJsdocNode();
+                if (doc.HasInheritDoc()) docNode.AddTag(DocTag.Inheritdoc);
                 if (doc.HasSummary()) docNode.Description = doc.Summary.Text;
                 result.Documentation = docNode;
             }
@@ -205,8 +206,8 @@ namespace Reinforced.Typings.Generators
                     // but still. It is better thatn nothing
 
                     if (sw.Documentation == null) sw.Documentation = new RtJsdocNode();
-                    sw.Documentation.TagToDescription.Add(new Tuple<DocTag, string>(DocTag.Todo,
-                        string.Format("Automatically implemented from {0}", resolver.ResolveTypeName(element._BaseType()))));
+                    sw.Documentation.AddTag(DocTag.Todo,
+                        string.Format("Automatically implemented from {0}", resolver.ResolveTypeName(element._BaseType())));
 
                     var baseBlueprint = Context.Project.Blueprint(element._BaseType());
                     var basExSwtch = baseBlueprint.Attr<TsInterfaceAttribute>();

--- a/Reinforced.Typings/Generators/ConstructorCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/ConstructorCodeGenerator.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Reinforced.Typings.Ast;
 using Reinforced.Typings.Attributes;
 using Reinforced.Typings.Exceptions;
+using Reinforced.Typings.Xmldoc.Model;
 
 namespace Reinforced.Typings.Generators
 {
@@ -26,13 +27,14 @@ namespace Reinforced.Typings.Generators
             var doc = Context.Documentation.GetDocumentationMember(element);
             if (doc != null)
             {
-                RtJsdocNode jsdoc = new RtJsdocNode { Description = doc.Summary.Text };
+                RtJsdocNode jsdoc = new RtJsdocNode();
+                if (doc.HasInheritDoc()) jsdoc.AddTag(DocTag.Inheritdoc);
+                if (doc.HasSummary()) jsdoc.Description = doc.Summary.Text;
                 if (doc.Parameters != null)
                 {
                     foreach (var documentationParameter in doc.Parameters)
                     {
-                        jsdoc.TagToDescription.Add(new Tuple<DocTag, string>(DocTag.Param,
-                            documentationParameter.Name + " " + documentationParameter.Description));
+                        jsdoc.AddTag(DocTag.Param, documentationParameter.Name + " " + documentationParameter.Description);
                     }
                 }
 

--- a/Reinforced.Typings/Generators/EnumGenerator.cs
+++ b/Reinforced.Typings/Generators/EnumGenerator.cs
@@ -33,6 +33,7 @@ namespace Reinforced.Typings.Generators
             if (doc != null)
             {
                 RtJsdocNode docNode = new RtJsdocNode();
+                if (doc.HasInheritDoc()) docNode.AddTag(DocTag.Inheritdoc);
                 if (doc.HasSummary()) docNode.Description = doc.Summary.Text;
                 result.Documentation = docNode;
             }
@@ -76,6 +77,7 @@ namespace Reinforced.Typings.Generators
                     if (valueDoc != null)
                     {
                         RtJsdocNode docNode = new RtJsdocNode();
+                        if (valueDoc.HasInheritDoc()) docNode.AddTag(DocTag.Inheritdoc);
                         if (valueDoc.HasSummary()) docNode.Description = valueDoc.Summary.Text;
                         value.Documentation = docNode;
                     }

--- a/Reinforced.Typings/Generators/MethodCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/MethodCodeGenerator.cs
@@ -33,19 +33,20 @@ namespace Reinforced.Typings.Generators
             var doc = Context.Documentation.GetDocumentationMember(element);
             if (doc != null)
             {
-                RtJsdocNode jsdoc = new RtJsdocNode { Description = doc.Summary.Text };
+                RtJsdocNode jsdoc = new RtJsdocNode();
+                if (doc.HasInheritDoc()) jsdoc.AddTag(DocTag.Inheritdoc);
+                if (doc.HasSummary()) jsdoc.Description = doc.Summary.Text;
                 if (doc.Parameters != null)
                 {
                     foreach (var documentationParameter in doc.Parameters)
                     {
-                        jsdoc.TagToDescription.Add(new Tuple<DocTag, string>(DocTag.Param,
-                            documentationParameter.Name + " " + documentationParameter.Description));
+                        jsdoc.AddTag(DocTag.Param, documentationParameter.Name + " " + documentationParameter.Description);
                     }
                 }
 
                 if (doc.HasReturns())
                 {
-                    jsdoc.TagToDescription.Add(new Tuple<DocTag, string>(DocTag.Returns, doc.Returns.Text));
+                    jsdoc.AddTag(DocTag.Returns, doc.Returns.Text);
                 }
                 result.Documentation = jsdoc;
             }

--- a/Reinforced.Typings/Generators/PropertyCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/PropertyCodeGenerator.cs
@@ -4,6 +4,7 @@ using System.Reflection;
 using Reinforced.Typings.Ast;
 using Reinforced.Typings.Ast.TypeNames;
 using Reinforced.Typings.Attributes;
+using Reinforced.Typings.Xmldoc.Model;
 
 namespace Reinforced.Typings.Generators
 {
@@ -44,7 +45,9 @@ namespace Reinforced.Typings.Generators
             var doc = Context.Documentation.GetDocumentationMember(element);
             if (doc != null)
             {
-                RtJsdocNode jsdoc = new RtJsdocNode { Description = doc.Summary.Text };
+                RtJsdocNode jsdoc = new RtJsdocNode();
+                if (doc.HasInheritDoc()) jsdoc.AddTag(DocTag.Inheritdoc);
+                if (doc.HasSummary()) jsdoc.Description = doc.Summary.Text;
                 result.Documentation = jsdoc;
             }
 

--- a/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtSimpleTypeName.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtSimpleTypeName.cs
@@ -8,7 +8,7 @@ namespace Reinforced.Typings.Visitors.TypeScript
 
         public override void Visit(RtSimpleTypeName node)
         {
-            if (!string.IsNullOrEmpty(node.Prefix))
+            if (node.HasPrefix)
             {
                 Write(node.Prefix);
                 Write(".");

--- a/Reinforced.Typings/Xmldoc/DocumentationManager.cs
+++ b/Reinforced.Typings/Xmldoc/DocumentationManager.cs
@@ -192,7 +192,7 @@ namespace Reinforced.Typings.Xmldoc
                 return GetDocumentationMember(info);
             }
             var doc = _documentationCache[id];
-            if (!doc.HasSummary()) return null;
+            if (!doc.HasInheritDoc() && !doc.HasSummary()) return null;
             return doc;
         }
 
@@ -209,7 +209,7 @@ namespace Reinforced.Typings.Xmldoc
             if (!_documentationCache.ContainsKey(id)) return null;
             var doc = _documentationCache[id];
 
-            if ((!doc.HasSummary()) && (!doc.HasParameters()) && (!doc.HasReturns())) return null;
+            if (!doc.HasInheritDoc() && !doc.HasSummary() && !doc.HasParameters() && !doc.HasReturns()) return null;
             return doc;
         }
 
@@ -224,7 +224,7 @@ namespace Reinforced.Typings.Xmldoc
             var id = GetIdentifierForConstructor(constructor);
             if (!_documentationCache.ContainsKey(id)) return null;
             var doc = _documentationCache[id];
-            if ((!doc.HasSummary()) && (!doc.HasParameters())) return null;
+            if (!doc.HasInheritDoc() && !doc.HasSummary() && !doc.HasParameters()) return null;
             return doc;
         }
 
@@ -240,7 +240,7 @@ namespace Reinforced.Typings.Xmldoc
             var id = GetIdentifierForType(type);
             if (!_documentationCache.ContainsKey(id)) return null;
             var typeDoc = _documentationCache[id];
-            if (!typeDoc.HasSummary()) return null;
+            if (!typeDoc.HasInheritDoc() && !typeDoc.HasSummary()) return null;
             return typeDoc;
         }
     }

--- a/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
+++ b/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
@@ -16,6 +16,11 @@
             return DocumentationMemberType.Unknown;
         }
 
+        public static bool HasInheritDoc(this DocumentationMember dm)
+        {
+            return dm.InheritDoc != null;
+        }
+
         public static bool HasSummary(this DocumentationMember dm)
         {
             return dm.Summary != null && !string.IsNullOrEmpty(dm.Summary.Text);

--- a/Reinforced.Typings/Xmldoc/Model/Model.cs
+++ b/Reinforced.Typings/Xmldoc/Model/Model.cs
@@ -1,5 +1,7 @@
-﻿using System.Xml;
+﻿using System;
+using System.Xml;
 using System.Xml.Serialization;
+using Reinforced.Typings.Ast;
 
 #pragma warning disable 1591
 
@@ -36,6 +38,9 @@ namespace Reinforced.Typings.Xmldoc.Model
 
         [XmlElement(ElementName = "summary")]
         public DocumentationSummary Summary { get; set; }
+
+        [XmlElement(ElementName = "inheritdoc")]
+        public DocumentationInheritDoc InheritDoc { get; set; }
 
         [XmlElement(ElementName = "param")]
         public DocumentationParameter[] Parameters { get; set; }
@@ -84,6 +89,24 @@ namespace Reinforced.Typings.Xmldoc.Model
         {
             Cref = reader.GetAttribute("cref");
             Text = reader.ReadInnerXml().Trim();
+        }
+    }
+
+    public class DocumentationInheritDoc : XmlIgnoreInner
+    {
+        /// <summary>
+        /// TODO: Find a type by this cref and get its documentation?
+        /// </summary>
+        public string Cref { get; set; }
+
+        public override string ToString()
+        {
+            return string.Empty;
+        }
+
+        public override void ReadXml(XmlReader reader)
+        {
+            Cref = reader.GetAttribute("cref");
         }
     }
 


### PR DESCRIPTION
`<inheritdoc/>` in XML docs is now carried over to JSDOC as `@inheritdoc`.

Don't know whether this library needs support of `<inheritdoc cref="SomeClass"/>` or how to resolve the reference under `cref`.