### PR TITLE
use public access modifier for FilesOperations

### DIFF
--- a/Reinforced.Typings/FilesOperations.cs
+++ b/Reinforced.Typings/FilesOperations.cs
@@ -10,7 +10,7 @@ using Reinforced.Typings.Visitors.Typings;
 
 namespace Reinforced.Typings
 {
-    internal class FilesOperations : IFilesOperations
+    public class FilesOperations : IFilesOperations
     {
         private readonly List<string> _tmpFiles = new List<string>();
 


### PR DESCRIPTION
Hi @pavel-b-novikov,


I would like to expose FilesOperations, which would allow to trigger generating typescript files at runtime (i.e. as discussed here: https://github.com/reinforced/Reinforced.Typings/issues/156#issuecomment-653226508)