### PR TITLE
fix #182: introduce RtAsyncType to handle "Promise" return type

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoAsync.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoAsync.cs
@@ -37,6 +37,11 @@ namespace Reinforced.Typings.Tests.SpecificCases
         Task<string> DoArgument();
     }
 
+    interface ITestAsyncParameter
+    {
+        Task<string> EvaluatePromise(Task<string> taskParameter);
+    }
+
     public partial class SpecificTestCases
     {
         [Fact]
@@ -98,6 +103,22 @@ module Reinforced.Typings.Tests.SpecificCases {
             AssertConfiguration(s =>
             {
                 s.ExportAsInterface<ITestAsync>().WithPublicMethods();
+            }, result);
+        }
+
+        [Fact]
+        public void PromiseTaskInParamterIsMaintained()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface ITestAsyncParameter
+	{
+		EvaluatePromise(taskParameter: Promise<string>) : string;
+	}
+}";
+            AssertConfiguration(s =>
+            {
+                s.ExportAsInterface<ITestAsyncParameter>().WithPublicMethods();
             }, result);
         }
     }

--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoAsync.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoAsync.cs
@@ -29,6 +29,14 @@ namespace Reinforced.Typings.Tests.SpecificCases
             return "aaa";
         }
     }
+
+    interface ITestAsync
+    {
+        Task DoVoid();
+
+        Task<string> DoArgument();
+    }
+
     public partial class SpecificTestCases
     {
         [Fact]
@@ -55,6 +63,41 @@ module Reinforced.Typings.Tests.SpecificCases {
                 s.Global(a => a.DontWriteWarningComment().AutoAsync());
                 s.ExportAsClass<TestAsync>().WithPublicMethods();
                 s.ExportAsInterface<TestAsync2>().WithPublicMethods();
+            }, result);
+        }
+
+        [Fact]
+        public void AutoAsyncInterfaceWorks()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface ITestAsync
+	{
+		DoVoid() : Promise<void>;
+		DoArgument() : Promise<string>;
+	}
+}";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment().AutoAsync());
+                s.ExportAsInterface<ITestAsync>().WithPublicMethods();
+            }, result);
+        }
+
+        [Fact]
+        public void NoAutoAsyncInterfaceWorks()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface ITestAsync
+	{
+		DoVoid() : void;
+		DoArgument() : string;
+	}
+}";
+            AssertConfiguration(s =>
+            {
+                s.ExportAsInterface<ITestAsync>().WithPublicMethods();
             }, result);
         }
     }

--- a/Reinforced.Typings/Ast/TypeNames/RtAsyncType.cs
+++ b/Reinforced.Typings/Ast/TypeNames/RtAsyncType.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Reinforced.Typings.Ast.TypeNames
+{
+    /// <summary>
+    /// AST node for async return types of type "Promise".
+    /// </summary>
+    /// <remarks>With TypeScript, "Promise" use "generics" to define the resulting type of the "Promise". This is
+    /// defined by a nested <see cref="TypeNameOfAsync"/></remarks>
+    public sealed class RtAsyncType : RtTypeName
+    {
+        /// <summary>
+        /// Constructs new instance of AST node
+        /// </summary>
+        public RtAsyncType(RtTypeName nestedType)
+            : this()
+        {
+            TypeNameOfAsync = nestedType;
+        }
+
+        /// <summary>
+        /// Type name
+        /// </summary>
+        public RtTypeName TypeNameOfAsync { get; private set; }
+
+        /// <summary>
+        /// Constructs new instance of AST node
+        /// </summary>
+        public RtAsyncType()
+        {
+        }
+
+        /// <inheritdoc />
+        public override IEnumerable<RtNode> Children
+        {
+            get { yield break; }
+        }
+
+        /// <inheritdoc />
+        public override void Accept(IRtVisitor visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <inheritdoc />
+        public override void Accept<T>(IRtVisitor<T> visitor)
+        {
+            visitor.Visit(this);
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            return $"Promise<{TypeNameOfAsync?.ToString() ?? "void"}>";
+        }
+    }
+}

--- a/Reinforced.Typings/Generators/MethodCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/MethodCodeGenerator.cs
@@ -93,7 +93,7 @@ namespace Reinforced.Typings.Generators
         protected RtTypeName ResolveAsyncReturnType(TsFunctionAttribute fa, MethodInfo element, TypeResolver resolver)
         {
             bool needAsync = (fa != null && fa.ForceAsync == true) || (Context.Global.AutoAsync && element.IsAsync())
-                || (Context.Global.AutoAsync && element.ReturnType.IsTask());
+                || (Context.Global.AutoAsync && element.ReturnType._IsAsyncType());
 
             return resolver.ResolveTypeName(element.ReturnType, needAsync);
         }

--- a/Reinforced.Typings/Generators/MethodCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/MethodCodeGenerator.cs
@@ -92,9 +92,7 @@ namespace Reinforced.Typings.Generators
 
         protected RtTypeName ResolveAsyncReturnType(TsFunctionAttribute fa, MethodInfo element, TypeResolver resolver)
         {
-            bool needAsync = (fa != null && fa.ForceAsync == true) || (Context.Global.AutoAsync && element.IsAsync())
-                || (Context.Global.AutoAsync && element.ReturnType._IsAsyncType());
-
+            bool needAsync = (fa != null && fa.ForceAsync == true) || (Context.Global.AutoAsync && element.IsAsync());
             return resolver.ResolveTypeName(element.ReturnType, needAsync);
         }
 

--- a/Reinforced.Typings/TypeExtensions.cs
+++ b/Reinforced.Typings/TypeExtensions.cs
@@ -570,7 +570,7 @@ namespace Reinforced.Typings
         /// </summary>
         /// <param name="t">Type to check</param>
         /// <returns>True when type is tuple, false otherwise</returns>
-        public static bool IsTask(this Type t)
+        public static bool _IsAsyncType(this Type t)
         {
             return t._IsAssignableFrom(typeof(Task)) || (
                 t._IsGenericType()

--- a/Reinforced.Typings/TypeExtensions.cs
+++ b/Reinforced.Typings/TypeExtensions.cs
@@ -565,6 +565,23 @@ namespace Reinforced.Typings
             return typeof(MulticastDelegate)._IsAssignableFrom(t._BaseType());
         }
 
+        /// <summary>
+        /// Determines if type is one of System.Tuple types set
+        /// </summary>
+        /// <param name="t">Type to check</param>
+        /// <returns>True when type is tuple, false otherwise</returns>
+        public static bool IsTask(this Type t)
+        {
+            return t._IsAssignableFrom(typeof(Task)) || (
+                t._IsGenericType()
+                && t.BaseType != null
+                && t.BaseType._IsAssignableFrom(typeof(Task))
+
+                // exclude "object" as "Task" is assignable to it, too
+                && !t.BaseType._IsAssignableFrom(typeof(Object))
+            );
+        }
+
 #endregion
 
 #region Modifiers

--- a/Reinforced.Typings/TypeExtensions.cs
+++ b/Reinforced.Typings/TypeExtensions.cs
@@ -618,7 +618,7 @@ namespace Reinforced.Typings
         public static bool IsAsync(this MethodInfo methodInfo)
         {
             var ret = methodInfo.ReturnType;
-            return typeof(Task)._IsAssignableFrom(ret);
+            return ret._IsAsyncType();
         }
 
         /// <summary>

--- a/Reinforced.Typings/TypeResolver.cs
+++ b/Reinforced.Typings/TypeResolver.cs
@@ -303,7 +303,7 @@ namespace Reinforced.Typings
                 if (enumerable == null) return Cache(t, new RtArrayType(AnyType));
                 return Cache(t, new RtArrayType(ResolveTypeName(enumerable.GetArg())));
             }
-            if (t.IsTask())
+            if (t._IsAsyncType())
             {
                 var deliveredTypeOfTask =
                     t._IsGenericType() ? ResolveTypeName(t.GetArg(), usePromiseType) : ResolveTypeName(typeof(void));

--- a/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtFunction.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtFunction.cs
@@ -25,15 +25,7 @@ namespace Reinforced.Typings.Visitors.TypeScript
             if (node.ReturnType != null)
             {
                 Write(": ");
-                if (node.IsAsync)
-                {
-                    Write("Promise<");
-                }
                 Visit(node.ReturnType);
-                if (node.IsAsync)
-                {
-                    Write(">");
-                }
             }
 
             if (Context == WriterContext.Interface)
@@ -48,7 +40,7 @@ namespace Reinforced.Typings.Visitors.TypeScript
                 }
                 else
                 {
-                    EmptyBody(node.ReturnType);
+                    EmptyBody(node.ReturnType, node.IsAsync);
                 }
             }
 

--- a/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.cs
@@ -82,8 +82,24 @@ namespace Reinforced.Typings.Visitors.TypeScript
         /// Writes empty method body of known return type
         /// </summary>
         /// <param name="returnType">Method return type</param>
-        protected void EmptyBody(RtTypeName returnType)
+        /// <param name="isAsyncMethod">Whether the method is tagged as "async", then no Promise need to be created
+        /// directly. TypeScript compiler does it for us.</param>
+        protected void EmptyBody(RtTypeName returnType, bool isAsyncMethod = false)
         {
+            // unfold the Promise return value
+            if (returnType is RtAsyncType)
+            {
+                if (isAsyncMethod)
+                {
+                    returnType = ((RtAsyncType) returnType).TypeNameOfAsync;
+                }
+                else
+                {
+                    CodeBlock("return Promise.resolve(null);");
+                    return;
+                }
+            }
+
             if (returnType == null || returnType.IsVoid())
             {
                 WriteLine(" { } ");

--- a/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtAsyncType.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/Types/TypeScriptExportVisitor.RtAsyncType.cs
@@ -1,0 +1,21 @@
+using Reinforced.Typings.Ast.TypeNames;
+#pragma warning disable 1591
+namespace Reinforced.Typings.Visitors.TypeScript
+{
+    partial class TypeScriptExportVisitor
+    {
+        #region Types
+
+        public override void Visit(RtAsyncType node)
+        {
+            Write("Promise<");
+
+            if (node.TypeNameOfAsync != null) this.Visit(node.TypeNameOfAsync);
+            else Write("void");
+
+            Write(">");
+        }
+
+        #endregion
+    }
+}

--- a/Reinforced.Typings/Visitors/VisitorBase.cs
+++ b/Reinforced.Typings/Visitors/VisitorBase.cs
@@ -30,6 +30,7 @@ namespace Reinforced.Typings.Visitors
             if (node is RtDecorator) { Visit((RtDecorator)node); return; }
             if (node is RtReference) { Visit((RtReference)node); return; }
             if (node is RtTuple) { Visit((RtTuple)node); return; }
+            if (node is RtAsyncType) { Visit((RtAsyncType)node); return; }
 
             throw new Exception("Unknown node passed");
         }
@@ -54,6 +55,7 @@ namespace Reinforced.Typings.Visitors
         public abstract void Visit(RtDecorator node);
         public abstract void Visit(RtReference node);
         public abstract void Visit(RtTuple node);
+        public abstract void Visit(RtAsyncType node);
         public abstract void VisitFile(ExportedFile file);
     }
 }


### PR DESCRIPTION
Converting interfaces that declare async methods via return type
`Task` fails currently. The result does not contain any Promise
return type, but just `any`. A return value of `Task` is an
implicit declaration of asynchronous function. Since
interfaces to not contain implementation of functions, the
explicit defining keyword `async` is not supported.

So far, automatic detection of async functions was insufficient.

This commit introduces a new return type `RtAsyncType` that
handles proper creation of TypeScript type declaration.
Once a method returns `Task` and `AutoAsync` flag is enabled,
the return value `Promise` is used with TypeScript code.

If the  `AutoAsync` flag is not enabled, then the async
 (Promise) value is unfolded instead of just converted to
`any`.

Converting an empty function body takes the "async" keyword
into consideration, too. If a function is NOT "async" but
returns a Promise, then a proper Promise is created instead
of just `null`.