### PR TITLE
detect nullable environment on C# >= 8.0

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoOptionalWithCompilerNullable.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoOptionalWithCompilerNullable.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using Reinforced.Typings.Fluent;
+using Xunit;
+
+#nullable enable
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        public interface OptionalTestInterfaceNullableAttribute
+        {
+            DateTime? Date { get; }
+            int Number { get; }
+            public int[]? Numbers { get; }
+            string? String { get; set; }
+            public IList<int>? SomeList { get; }
+        }
+
+        public class OptionalTestClassNullableAttribute
+        {
+            public DateTime? Date { get; }
+            public int? Number { get; }
+            public int[] Numbers { get; }
+            public string String { get; }
+            public IList<int> SomeList { get; }
+        }
+
+        [Fact]
+        public void AutoOptionalIfCompilerNullableAttribute()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface IOptionalTestInterfaceNullableAttribute
+	{
+		Date?: any;
+		Number: number;
+		Numbers?: number[];
+		String?: string;
+		SomeList?: number[];
+	}
+	export interface IOptionalTestClassNullableAttribute
+	{
+		Date?: any;
+		Number?: number;
+		Numbers: number[];
+		String: string;
+		SomeList: number[];
+	}
+}";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment().AutoOptionalProperties());
+                s.ExportAsInterface<OptionalTestInterfaceNullableAttribute>().WithPublicProperties();
+                s.ExportAsInterface<OptionalTestClassNullableAttribute>().WithPublicProperties();
+            }, result);
+        }
+        
+        public interface OptionalTestParameterInterfaceNullableAttribute
+        {
+	        public int TransformSomeValue(int mode, string? data);
+	        public string TransformSomeValueNonNullParameter(int mode, string data);
+        }
+
+        [Fact]
+        public void AutoOptionalOfParameterIfCompilerNullableAttribute()
+        {
+	        const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export interface IOptionalTestParameterInterfaceNullableAttribute
+	{
+		TransformSomeValue(mode: number, data?: string) : number;
+		TransformSomeValueNonNullParameter(mode: number, data: string) : string;
+	}
+}";
+	        AssertConfiguration(s =>
+	        {
+		        s.Global(a => a.DontWriteWarningComment().AutoOptionalProperties());
+		        s.ExportAsInterface<OptionalTestParameterInterfaceNullableAttribute>().WithPublicMethods();
+	        }, result);
+        }
+    }
+}

--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoOptionalWithCompilerNullable.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.AutoOptionalWithCompilerNullable.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if CUSTOM_FLAG_NULLABLE_AVAILABLE
+using System;
 using System.Collections.Generic;
 using Reinforced.Typings.Fluent;
 using Xunit;
@@ -82,3 +83,5 @@ module Reinforced.Typings.Tests.SpecificCases {
         }
     }
 }
+
+#endif

--- a/Reinforced.Typings/Generators/ParameterCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/ParameterCodeGenerator.cs
@@ -35,7 +35,7 @@ namespace Reinforced.Typings.Generators
                 else if (fa.StrongType != null)
                 {
                     type = resolver.ResolveTypeName(fa.StrongType);
-                    isNullable = element.IsOptional;
+                    isNullable = element.IsOptional || element.IsReferenceForcedNullable();
                 }
                 else type = resolver.ResolveTypeName(element.ParameterType);
                 type = fa.TypeInferers.Infer(element, resolver) ?? type;
@@ -43,7 +43,7 @@ namespace Reinforced.Typings.Generators
             else
             {
                 type = resolver.ResolveTypeName(element.ParameterType);
-                isNullable = element.IsOptional;
+                isNullable = element.IsOptional || element.IsReferenceForcedNullable();
             }
             if (element.GetCustomAttribute<ParamArrayAttribute>() != null)
             {

--- a/Reinforced.Typings/Generators/PropertyCodeGenerator.cs
+++ b/Reinforced.Typings/Generators/PropertyCodeGenerator.cs
@@ -79,7 +79,8 @@ namespace Reinforced.Typings.Generators
             
             if (!Context.SpecialCase)
             {
-                propName.IsNullable = HasToBeNullable(tp, t);
+                propName.IsNullable = HasToBeNullable(tp, t) 
+                                      || Context.Global.AutoOptionalProperties && element.IsReferenceForcedNullable();
             }
 
             if (type == null) type = resolver.ResolveTypeName(t);

--- a/Reinforced.Typings/TypeExtensions.cs
+++ b/Reinforced.Typings/TypeExtensions.cs
@@ -831,7 +831,7 @@ namespace Reinforced.Typings
             // need to retrieve all attributes and find by class name.
             // see: http://code.fitness/post/2019/02/nullableattribute.html
             // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
-            foreach(var customAttribute in member.GetCustomAttributes(true))
+            foreach(var customAttribute in member?.GetCustomAttributes(true) ?? Array.Empty<object>())
             {
                 if (customAttribute is Attribute nullableAttribute) 
                 {

--- a/Reinforced.Typings/TypeExtensions.cs
+++ b/Reinforced.Typings/TypeExtensions.cs
@@ -88,6 +88,45 @@ namespace Reinforced.Typings
             return CustomAttributeExtensions.GetCustomAttributes<T>(t.GetTypeInfo(), inherit);
         }
 #endif
+        
+        public static bool IsReferenceForcedNullable(this MemberInfo member)
+        {
+            // non reference types will be converted to Nullable<> if they are nullable.
+            // C# 8.0 nullable flag just changes the way reference types are handled. If enabled, then they are
+            // not implicitly nullable anymore!
+            Type memberType = member is PropertyInfo propertyInfo ? propertyInfo.PropertyType : (
+                member is FieldInfo fieldInfo ? fieldInfo.FieldType : null
+            );
+
+            if (memberType != null && memberType._IsReferenceType())
+            {
+                byte[] nullableFlag = GetNullableAttributeValue(member, false) ??
+                                      GetNullableAttributeValue(member.DeclaringType, true);
+
+                return nullableFlag != null && nullableFlag.Length > 0 && nullableFlag[0] == 2;
+            }
+
+            return false;
+        }
+
+        public static bool IsReferenceForcedNullable(this ParameterInfo member)
+        {
+            // non reference types will be converted to Nullable<> if they are nullable.
+            // C# 8.0 nullable flag just changes the way reference types are handled. If enabled, then they are
+            // not implicitly nullable anymore!
+            Type memberType = member.ParameterType;
+            if (member.ParameterType._IsReferenceType())
+            {
+                byte[] nullableFlag = GetNullableAttributeValue(member, false) ??
+                                      GetNullableAttributeValue(member.Member, true) ??
+                                      GetNullableAttributeValue(member.Member.DeclaringType, true);
+
+                return nullableFlag != null && nullableFlag.Length > 0 && nullableFlag[0] == 2;
+            }
+
+            return false;
+        }
+
         internal static bool _IsGenericType(this Type t)
         {
 #if NETCORE
@@ -155,6 +194,20 @@ namespace Reinforced.Typings
 #else
             return t.IsInterface;
 #endif
+        }
+
+        internal static bool _IsArray(this Type t)
+        {
+#if NETCORE
+            return t.GetTypeInfo().IsArray;
+#else
+            return t.IsArray;
+#endif
+        }
+
+        internal static bool _IsReferenceType(this Type t)
+        {
+            return t._IsClass() || t._IsInterface() || t._IsArray() || typeof(string)._IsAssignableFrom(t);
         }
 
         internal static IEnumerable<Type> _GetInterfaces(this Type t)
@@ -773,7 +826,46 @@ namespace Reinforced.Typings
 
 #endregion
 
+        private static byte[] GetNullableAttributeValue(this ICustomAttributeProvider member, bool fromParent = false)
+        {
+            // need to retrieve all attributes and find by class name.
+            // see: http://code.fitness/post/2019/02/nullableattribute.html
+            // https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
+            foreach(var customAttribute in member.GetCustomAttributes(true))
+            {
+                if (customAttribute is Attribute nullableAttribute) 
+                {
+                    bool isNullableAttribute = string.Equals(
+                        customAttribute.GetType().FullName, 
+                        "System.Runtime.CompilerServices.NullableAttribute",
+                        StringComparison.InvariantCulture
+                    ); 
 
+                    bool isNullableContextAttribute = fromParent && !isNullableAttribute && string.Equals(
+                       customAttribute.GetType().FullName, 
+                       "System.Runtime.CompilerServices.NullableContextAttribute",
+                       StringComparison.InvariantCulture
+                    );
 
+                    if (!isNullableAttribute && !isNullableContextAttribute)
+                    {
+                        continue;
+                    }
+
+                    FieldInfo flagField = isNullableAttribute
+                        ? nullableAttribute.GetType().GetRuntimeField("NullableFlags")
+                        : nullableAttribute.GetType().GetRuntimeField("Flag");
+                        
+                    object flagsData = flagField?.GetValue(nullableAttribute);
+                    byte[] flags = flagsData is byte[] flagsDataBytes ? flagsDataBytes : null;
+                    flags = flags is null && flagsData is byte flagsDataSingleByte ?
+                        new byte[] {flagsDataSingleByte} : flags;
+
+                    return flags != null && flags.Length > 0 ? flags : null;
+                }
+            }
+
+            return null;
+        }
     }
 }


### PR DESCRIPTION
With C# compiler higher than 8.0 a new flag has been introduced to invert the nullability of reference types.
The flag can be set globally per project or for each file.

The file flag is:
```
#nullable enable
```

If this flag is enabled, reference types are not implicitly nullable anymore. Nullability must be set explicitly. In such cases, the types should be exported with this explicit nullability to TypeScript too.
The compiler attaches additional attributes to the member/parameter information. This way, the generated code is stil backwards compatible with older C# IDL versions.

If this flag is not set, then the new code will not take any effect as the additional attributes will not be not attached.

see:
* https://github.com/dotnet/roslyn/blob/master/docs/features/nullable-metadata.md
* https://codeblog.jonskeet.uk/2019/02/10/nullableattribute-and-c-8/


fixes #145 


I'd welcome any hints for code improvement.
