### PR TITLE
fix: introduce `FieldExportBuilder`

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.Fields.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.Fields.cs
@@ -1,0 +1,38 @@
+﻿using Reinforced.Typings.Fluent;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+	    class TestExportWithFields
+	    {
+		    public string StringField;
+		    public int NumberField;
+	    }
+
+	    [Fact]
+        public void FieldsWithBuilderConfig()
+        {
+            const string result = @"
+				class TestExportWithFields
+					{
+						public StringField: string;
+						public NumberField: number;
+					}
+				";
+
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment());
+                s.ExportAsClass<TestExportWithFields>()
+	                .WithPublicFields((config) =>
+	                {
+		                var fieldInfo = config.Member;
+	                })
+	                .DontIncludeToNamespace()
+	            ;
+            }, result);
+        }
+    }
+}

--- a/Reinforced.Typings/Fluent/MemberBuilders/MemberExportBuilder.Field.cs
+++ b/Reinforced.Typings/Fluent/MemberBuilders/MemberExportBuilder.Field.cs
@@ -1,0 +1,24 @@
+﻿using System.Reflection;
+// ReSharper disable CheckNamespace
+
+namespace Reinforced.Typings.Fluent
+{
+    /// <summary>
+    /// Fluent export configuration builder for a field
+    /// </summary>
+    public class FieldExportBuilder : PropertyExportBuilder
+    {
+        /// <summary>Initializes a new instance of the <see cref="T:System.Object" /> class.</summary>
+        internal FieldExportBuilder(TypeBlueprint containingTypeBlueprint, MemberInfo member) : base(containingTypeBlueprint, member)
+        {
+        }
+
+        /// <summary>
+        /// Gets property being configured
+        /// </summary>
+        public new FieldInfo Member
+        {
+            get { return (FieldInfo) _member; }
+        }
+    }
+}

--- a/Reinforced.Typings/Fluent/MemberExtensions/MemberExportExtensions.Property.cs
+++ b/Reinforced.Typings/Fluent/MemberExtensions/MemberExportExtensions.Property.cs
@@ -21,7 +21,7 @@ namespace Reinforced.Typings.Fluent
         /// <summary>
         ///     Specifies code generator for member
         /// </summary>
-        public static PropertyExportBuilder WithFieldCodeGenerator<T>(this PropertyExportBuilder conf)
+        public static FieldExportBuilder WithFieldCodeGenerator<T>(this FieldExportBuilder conf)
             where T : ITsCodeGenerator<FieldInfo>
         {
             conf.Attr.CodeGeneratorType = typeof(T);

--- a/Reinforced.Typings/Fluent/TypeBuilders/TypeExportBuilder.ClassOrInterface.cs
+++ b/Reinforced.Typings/Fluent/TypeBuilders/TypeExportBuilder.ClassOrInterface.cs
@@ -44,7 +44,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="fields">Fields to include</param>
         /// <param name="configuration">Configuration to be applied to each field</param>
         /// <returns>Fluent</returns>
-        public void WithFields(IEnumerable<FieldInfo> fields, Action<PropertyExportBuilder> configuration = null)
+        public void WithFields(IEnumerable<FieldInfo> fields, Action<FieldExportBuilder> configuration = null)
         {
             ApplyMembersConfiguration(fields, configuration);
         }

--- a/Reinforced.Typings/Fluent/WithExtensions/WithExtensions.Fields.cs
+++ b/Reinforced.Typings/Fluent/WithExtensions/WithExtensions.Fields.cs
@@ -19,12 +19,12 @@ namespace Reinforced.Typings.Fluent
         /// <param name="tc">Configuration builder</param>
         /// <param name="field">Field to include</param>
         /// <returns>Fluent</returns>
-        public static PropertyExportBuilder WithField<T, TData>(this ITypedExportBuilder<T> tc,
+        public static FieldExportBuilder WithField<T, TData>(this ITypedExportBuilder<T> tc,
             Expression<Func<T, TData>> field)
         {
             var prop = LambdaHelpers.ParseFieldLambda(field);
             ClassOrInterfaceExportBuilder tcb = tc as ClassOrInterfaceExportBuilder;
-            return new PropertyExportBuilder(tcb.Blueprint, prop);
+            return new FieldExportBuilder(tcb.Blueprint, prop);
         }
 
         /// <summary>
@@ -34,7 +34,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="fieldName">Name of field to include</param>
         /// <param name="configuration">Configuration to be applied to selected field</param>
         /// <returns>Fluent</returns>
-        public static T WithField<T>(this T tc, string fieldName, Action<PropertyExportBuilder> configuration)
+        public static T WithField<T>(this T tc, string fieldName, Action<FieldExportBuilder> configuration)
             where T : ClassOrInterfaceExportBuilder
         {
             var field = tc.Blueprint.Type._GetField(fieldName);
@@ -56,7 +56,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="configuration">Configuration to be applied to each field</param>
         /// <returns>Fluent</returns>
         public static T WithFields<T>(this T tc, Func<FieldInfo, bool> predicate,
-            Action<PropertyExportBuilder> configuration = null) where T : ClassOrInterfaceExportBuilder
+            Action<FieldExportBuilder> configuration = null) where T : ClassOrInterfaceExportBuilder
         {
             var prop = tc.Blueprint.GetExportingMembers((t, b) => t._GetFields(b))
                 .Where(predicate);
@@ -70,7 +70,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="tc">Configuration builder</param>
         /// <param name="configuration">Configuration to be applied to each field</param>
         /// <returns>Fluent</returns>
-        public static T WithAllFields<T>(this T tc, Action<PropertyExportBuilder> configuration = null)
+        public static T WithAllFields<T>(this T tc, Action<FieldExportBuilder> configuration = null)
             where T : ClassOrInterfaceExportBuilder
         {
             var prop = tc.Blueprint.GetExportingMembers((t, b) => t._GetFields(b));
@@ -84,7 +84,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="tc">Configuration builder</param>
         /// <param name="configuration">Configuration to be applied to each field</param>
         /// <returns>Fluent</returns>
-        public static T WithPublicFields<T>(this T tc, Action<PropertyExportBuilder> configuration = null)
+        public static T WithPublicFields<T>(this T tc, Action<FieldExportBuilder> configuration = null)
             where T : ClassOrInterfaceExportBuilder
         {
             var prop =
@@ -102,7 +102,7 @@ namespace Reinforced.Typings.Fluent
         /// <param name="configuration">Configuration to be applied to each field</param>
         /// <returns>Fluent</returns>
         public static T WithFields<T>(this T tc, BindingFlags bindingFlags,
-            Action<PropertyExportBuilder> configuration = null) where T : ClassOrInterfaceExportBuilder
+            Action<FieldExportBuilder> configuration = null) where T : ClassOrInterfaceExportBuilder
         {
             var prop = tc.Blueprint.Type._GetFields(bindingFlags);
             tc.WithFields(prop, configuration);


### PR DESCRIPTION
A field export builder is being introduced to provide the properly typed `Member` property. Fields use
`FieldInfo`, whereas properties use `PropertyInfo`. So, using original `PropertyExportBuilder` with accessing the member info leads to a type cast exception.

Since the new `FieldExportBuilder` is a descendant of `PropertyExportBuilder`, it can be used as a
replacement seemlesly - where needed. All `withField...` are changed to use that new builder, giving consumers of the export config to access `FieldInfo`.

fixes: #190