### PR TITLE
fix: omit parameter initialiser in interfaces

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.FunctionWithParamInitialiser.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.FunctionWithParamInitialiser.cs
@@ -1,0 +1,73 @@
+﻿using System.Reflection;
+using Reinforced.Typings.Ast;
+using Reinforced.Typings.Attributes;
+using Reinforced.Typings.Fluent;
+using Reinforced.Typings.Generators;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        private class MyFunctionTestClassWithParamInitializer
+        {
+        
+            public string MyProperty { get; set; }
+        
+            public int MyNumber { get; set; }
+
+            public string DoSomething(int a = 4)
+            {
+                return a == 4 ? "Hello World" : string.Empty;
+            }
+        }
+
+        [Fact]
+        public void FunctionWithParamInitializerAsInterface()
+        {
+            const string result = @"
+                module Reinforced.Typings.Tests.SpecificCases {
+	                export interface IMyFunctionTestClassWithParamInitializer
+	                {
+		                MyProperty: string;
+		                MyNumber: number;
+		                doSomething(a?: number) : string;
+	                }
+                }
+            ";
+
+            AssertConfiguration(s =>
+            {
+                s.Global(x=>x.DontWriteWarningComment());
+                s.ExportAsInterface<MyFunctionTestClassWithParamInitializer>()
+                .WithPublicMethods(x=>x.CamelCase())
+                .WithPublicProperties();
+            }, result);
+        }
+
+        [Fact]
+        public void FunctionWithParamInitializerAsClass()
+        {
+            const string result = @"
+                module Reinforced.Typings.Tests.SpecificCases {
+	                export class MyFunctionTestClassWithParamInitializer
+	                {
+		                public MyProperty: string;
+		                public MyNumber: number;
+		                public doSomething(a: number = 4) : string
+		                {
+			                return null;
+		                }
+	                }
+                }
+                ";
+            AssertConfiguration(s =>
+            {
+                s.Global(x=>x.DontWriteWarningComment());
+                s.ExportAsClass<MyFunctionTestClassWithParamInitializer>()
+                    .WithPublicMethods(x=>x.CamelCase())
+                    .WithPublicProperties();
+            }, result);
+        }
+    }
+}

--- a/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtArgument.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.RtArgument.cs
@@ -10,9 +10,16 @@ namespace Reinforced.Typings.Visitors.TypeScript
             Decorators(node);
             if (node.IsVariableParameters) Write("...");
             Visit(node.Identifier);
+
+            // if a default value is used, then the parameter may be omitted as the default value is in place.
+            if (Context == WriterContext.Interface && !node.Identifier.IsNullable && !string.IsNullOrEmpty(node.DefaultValue))
+            {
+                Write("?");
+            }
+
             Write(": ");
             Visit(node.Type);
-            if (!string.IsNullOrEmpty(node.DefaultValue))
+            if (Context != WriterContext.Interface && !string.IsNullOrEmpty(node.DefaultValue))
             {
                 Write(" = ");
                 Write(node.DefaultValue);


### PR DESCRIPTION
Methods in interface may not have parameter default values ("initialisers"). TypeScript compiler 3.9.7 emits error TS2371 if such a default value is being found.

Such default value makes a parameter optional. So, instead of emitting the default value, the parameter is marked with "?". Then in can be omitted from the list of parameters as it would be with a default value.

fixes #191
