### PR TITLE
base class is treated as base interface if class is exported as interface

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.ThirdPartyWithBaseClass.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.ThirdPartyWithBaseClass.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Reinforced.Typings.Ast.Dependency;
+using Reinforced.Typings.Attributes;
+using Reinforced.Typings.Fluent;
+using Reinforced.Typings.ReferencesInspection;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        class ThirdPartyBaseClass
+        {
+            public string SomeProperty { get; set; }
+        }
+
+        class ExportedClass : ThirdPartyBaseClass
+        {
+            public int Property { get; set; }
+            public string GenericProperty1 { get; set; }
+        }
+
+        [Fact]
+        public void ExportAsInterfaceWithThirdPartyBaseClass()
+        {
+            const string file1 = @"import { IThirdPartyBaseInterface } from 'third-party';
+
+export interface IExportedClass extends IThirdPartyBaseInterface
+{
+  GenericProperty1: string;
+  Property: number;
+}
+";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment()
+                    .UseModules()
+                    .ReorderMembers());
+
+                s.ExportAsThirdParty<ThirdPartyBaseClass>()
+                    .WithName("IThirdPartyBaseInterface")
+                    .Imports(new RtImport()
+                    {
+                        From = "third-party",
+                        Target = "{ IThirdPartyBaseInterface }"
+                    });
+
+                s.ExportAsInterface<ExportedClass>().WithPublicProperties();
+            }, file1);
+        }
+
+        [Fact]
+        public void ExportAsClassWithThirdPartyBaseClass()
+        {
+            const string file1 = @"import { ThirdPartyBaseClass } from 'third-party';
+
+export class ExportedClass extends ThirdPartyBaseClass
+{
+	public GenericProperty1: string;
+	public Property: number;
+}
+";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment()
+                    .UseModules()
+                    .ReorderMembers());
+
+                s.ExportAsThirdParty<ThirdPartyBaseClass>()
+                    .WithName("ThirdPartyBaseClass")
+                    .Imports(new RtImport()
+                    {
+                        From = "third-party",
+                        Target = "{ ThirdPartyBaseClass }"
+                    });
+
+                s.ExportAsClass<ExportedClass>().WithPublicProperties();
+            }, file1);
+        }
+    }
+}

--- a/Reinforced.Typings/Generators/ClassAndInterfaceGeneratorBase.cs
+++ b/Reinforced.Typings/Generators/ClassAndInterfaceGeneratorBase.cs
@@ -80,7 +80,7 @@ namespace Reinforced.Typings.Generators
 
                     if (inferredBaseType != null)
                     {
-                        if (baseAsInterface)
+                        if (baseAsInterface || result is RtInterface)
                         {
                             implementees.Add(inferredBaseType);
                         }


### PR DESCRIPTION
If a class-type is exported as an interface but derives from a third-party base class, a type cast exception was thrown.
The exported expected a class-node (`RtClass`) during the export but apparently it is a `RtInterface`, because the type is
being exported as interface.

So, base classes are added to the list of `implementees` instead as there is no base class for an interface.

fixes: #189