### PR TITLE
feat:(build) add missing .NET core project files

### DIFF
--- a/Reinforced.Typings.NETCore.sln
+++ b/Reinforced.Typings.NETCore.sln
@@ -16,6 +16,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "cake", "cake", "{71091BA9-1
 		cake\build.sh = cake\build.sh
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Reinforced.Typings.Tests.NETCore", "Reinforced.Typings.Tests\Reinforced.Typings.Tests.NETCore.csproj", "{5D126898-7E5D-4967-8732-3FC8722F532E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestFluentAssembly.NETCore", "TestFluentAssembly\TestFluentAssembly.NETCore.csproj", "{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +66,30 @@ Global
 		{836424C9-8003-4C0F-84E1-2C17FE498648}.Release|x64.Build.0 = Release|x64
 		{836424C9-8003-4C0F-84E1-2C17FE498648}.Release|x86.ActiveCfg = Release|x86
 		{836424C9-8003-4C0F-84E1-2C17FE498648}.Release|x86.Build.0 = Release|x86
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|x64.Build.0 = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Debug|x86.Build.0 = Debug|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|x64.ActiveCfg = Release|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|x64.Build.0 = Release|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|x86.ActiveCfg = Release|Any CPU
+		{5D126898-7E5D-4967-8732-3FC8722F532E}.Release|x86.Build.0 = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|x64.Build.0 = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Debug|x86.Build.0 = Debug|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|x64.ActiveCfg = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|x64.Build.0 = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|x86.ActiveCfg = Release|Any CPU
+		{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Reinforced.Typings.Tests/Reinforced.Typings.Tests.NETCore.csproj
+++ b/Reinforced.Typings.Tests/Reinforced.Typings.Tests.NETCore.csproj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5D126898-7E5D-4967-8732-3FC8722F532E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Reinforced.Typings.Tests</RootNamespace>
+    <AssemblyName>Reinforced.Typings.Tests</AssemblyName>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1;netcoreapp2.2</TargetFrameworks>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\Reinforced.Typings.Tests.XML</DocumentationFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Reinforced.Typings.Cli\Reinforced.Typings.Cli.NETCore.csproj" />
+    <ProjectReference Include="..\Reinforced.Typings\Reinforced.Typings.NETCore.csproj" />
+    <ProjectReference Include="..\TestFluentAssembly\TestFluentAssembly.NETCore.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TestFluentAssembly/TestFluentAssembly.NETCore.csproj
+++ b/TestFluentAssembly/TestFluentAssembly.NETCore.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{E7E010D2-1CE5-4877-ABA7-36EA8EC62118}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TestFluentAssembly</RootNamespace>
+    <AssemblyName>TestFluentAssembly</AssemblyName>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp2.1;netcoreapp3.1;netcoreapp2.2</TargetFrameworks>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Some project files were missing to build the whole project
for .NET core. This is needed to build the project
on other platforms, like Mac OS or Linux.