### PR TITLE
Allow a custom Reinforced.Typings.settings.xml location.

### DIFF
--- a/stuff/Reinforced.Typings.targets
+++ b/stuff/Reinforced.Typings.targets
@@ -1,8 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
+	<PropertyGroup Condition="'$(RtSettingsXml)' == ''">
 		<RtSettingsXml Condition="HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)Reinforced.Typings.settings.xml</RtSettingsXml>
 		<RtSettingsXml Condition="!HasTrailingSlash('$(ProjectDir)')">$(ProjectDir)\Reinforced.Typings.settings.xml</RtSettingsXml>
+	</PropertyGroup>
 
+    <PropertyGroup>
 		<RtTargetsPath Condition=" '$(MSBuildRuntimeType)' == 'Core'">netstandard2.0</RtTargetsPath>
 		<RtTargetsPath Condition=" '$(MSBuildRuntimeType)' != 'Core'">net46</RtTargetsPath>
 	</PropertyGroup>


### PR DESCRIPTION
When Reinforced.Typings.targets creates the RtSettingsXml propery, it will now check it it has been defined previously.
If it has not been defined previously, it will construct RtSettingsXml to point to the default location.

This fixes #209.