### PR TITLE
convert unnecessary buildwarn to Console.WriteLine

### DIFF
--- a/Reinforced.Typings.Cli/AssemblyManager.cs
+++ b/Reinforced.Typings.Cli/AssemblyManager.cs
@@ -75,7 +75,7 @@ namespace Reinforced.Typings.Cli
                 {
                     if (!Path.IsPathRooted(assemblyPath))
                     {
-                        BuildWarn("Assembly {0} may be resolved incorrectly", new object[] { assemblyPath });
+                        Console.WriteLine("Assembly {0} may be resolved incorrectly", new object[] { assemblyPath });
                     }
 
                     try
@@ -148,7 +148,7 @@ namespace Reinforced.Typings.Cli
                 {
                     if (!Path.IsPathRooted(path))
                     {
-                        BuildWarn("Assembly {0} may be resolved incorrectly to {1}", new object[] { nm.Name, path });
+                        Console.WriteLine("Assembly {0} may be resolved incorrectly to {1}", new object[] { nm.Name, path });
                         continue;
                     }
                     
@@ -185,7 +185,7 @@ namespace Reinforced.Typings.Cli
                 {
                     if (!Path.IsPathRooted(path))
                     {
-                        BuildWarn("Assembly {0} may be resolved incorrectly to {1}", new object[] { nm.Name, path });
+                        Console.WriteLine("Assembly {0} may be resolved incorrectly to {1}", new object[] { nm.Name, path });
                         continue;
                     }
                     


### PR DESCRIPTION
These three warning lines don't actually constitute a warning (they all have subsequent catch blocks that are actual warnings), so should just be Console.WriteLines instead.

This fixes #213 .