### PR TITLE
Bugfix - use Ignored values configuration for enums

### DIFF
--- a/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
+++ b/Reinforced.Typings.Tests/Reinforced.Typings.Tests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="SpecificCases\SpecificTestCases.DaggmanoAutoIBug.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.DDanteInheritanceBug.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.DGoncharovGenericsCase.cs" />
+    <Compile Include="SpecificCases\SpecificTestCases.EnumStringInitializerIgnoreManyValues.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.ExportEnumsInDtsWithDeclareKeyword.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.GenericsExport3.cs" />
     <Compile Include="SpecificCases\SpecificTestCases.GenericsExport2.cs" />

--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumStringInitializerIgnoreManyValues.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumStringInitializerIgnoreManyValues.cs
@@ -3,32 +3,32 @@ using Xunit;
 
 namespace Reinforced.Typings.Tests.SpecificCases
 {
-    public partial class SpecificTestCases
-    {
-        enum EnumToIgnoreSomeValues
-        {
-            Value1, 
-            Value2, 
-            Value3
-        }
+	public partial class SpecificTestCases
+	{
+		enum EnumToIgnoreSomeValues
+		{
+			Value1, 
+			Value2, 
+			Value3
+		}
         
-        [Fact]
-        public void EnumMultipleIgnoreValues()
-        {
-            const string result = @"
+		[Fact]
+		public void EnumMultipleIgnoreValuesShouldPass()
+		{
+			const string result = @"
 module Reinforced.Typings.Tests.SpecificCases {
-	export enum SomeInitializerEnum { 
+	export enum EnumToIgnoreSomeValues { 
         Value3 = ""Value3"" 
     }
 }";
-            AssertConfiguration(s =>
-            {
-                s.Global(a => a.DontWriteWarningComment());
-                s.ExportAsEnum<EnumToIgnoreSomeValues>()
-                    .Value(EnumToIgnoreSomeValues.Value1, d => d.Ignore())
-                    .Value(EnumToIgnoreSomeValues.Value2, d => d.Ignore())
-                    .UseString();
-            }, result);
-        }
-    }
+			AssertConfiguration(s =>
+			{
+				s.Global(a => a.DontWriteWarningComment());
+				s.ExportAsEnum<EnumToIgnoreSomeValues>()
+					.Value(EnumToIgnoreSomeValues.Value1, d => d.Ignore())
+					.Value(EnumToIgnoreSomeValues.Value2, d => d.Ignore())
+					.UseString();
+			}, result);
+		}
+	}
 }

--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumStringInitializerIgnoreManyValues.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.EnumStringInitializerIgnoreManyValues.cs
@@ -1,0 +1,34 @@
+﻿using Reinforced.Typings.Fluent;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        enum EnumToIgnoreSomeValues
+        {
+            Value1, 
+            Value2, 
+            Value3
+        }
+        
+        [Fact]
+        public void EnumMultipleIgnoreValues()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	export enum SomeInitializerEnum { 
+        Value3 = ""Value3"" 
+    }
+}";
+            AssertConfiguration(s =>
+            {
+                s.Global(a => a.DontWriteWarningComment());
+                s.ExportAsEnum<EnumToIgnoreSomeValues>()
+                    .Value(EnumToIgnoreSomeValues.Value1, d => d.Ignore())
+                    .Value(EnumToIgnoreSomeValues.Value2, d => d.Ignore())
+                    .UseString();
+            }, result);
+        }
+    }
+}

--- a/Reinforced.Typings/Generators/EnumGenerator.cs
+++ b/Reinforced.Typings/Generators/EnumGenerator.cs
@@ -55,6 +55,9 @@ namespace Reinforced.Typings.Generators
                 {
                     var fieldItself = fields[n];
 
+                    if (Context.CurrentBlueprint.Ignored.Contains(fieldItself))
+                        continue;
+
                     var attr = Context.CurrentBlueprint.ForEnumValue(fieldItself);
                     if (attr != null) n = attr.Name;
                     if (string.IsNullOrEmpty(n)) n = fieldItself.Name;


### PR DESCRIPTION
ReinforcedTypings skips fluent configuration of ignored values for enum.

Test:
```

enum EnumToIgnoreSomeValues
        {
            Value1, 
            Value2, 
            Value3
        }
        
[Fact]
        public void EnumMultipleIgnoreValues()
        {
            const string result = @"
module Reinforced.Typings.Tests.SpecificCases {
	export enum SomeInitializerEnum { 
        Value3 = ""Value3"" 
    }
}";
            AssertConfiguration(s =>
            {
                s.Global(a => a.DontWriteWarningComment());
                s.ExportAsEnum<EnumToIgnoreSomeValues>()
                    .Value(EnumToIgnoreSomeValues.Value1, d => d.Ignore())
                    .Value(EnumToIgnoreSomeValues.Value2, d => d.Ignore())
                    .UseString();
            }, result);
        }
```