### PR TITLE
Mark as `developmentDependency`

### DIFF
--- a/stuff/Reinforced.Typings.nuspec
+++ b/stuff/Reinforced.Typings.nuspec
@@ -14,7 +14,8 @@
         <summary>Automated, reflection-based glue code generator for TypeScript</summary>
         <copyright>© 2019 Pavel B. Novikov</copyright>
         <language>en-US</language>
-        <tags>mvc, web, typescript</tags>		
+        <tags>mvc, web, typescript</tags>	
+        <developmentDependency>true</developmentDependency>	
         <license type="file">license\license.txt</license>
 		<releaseNotes>
 		


### PR DESCRIPTION
Mark as development dependency by adding `<developmentDependency>true</developmentDependency>` to `nuspec`.

This is in line with expectations from the consumers. This is also how other packages are marked, e.g.:
- Microsoft.VisualStudio.Threading.Analyzers
- Meziantou.Analyzer
- IDisposableAnalyzers
- AsyncFixer