### PR TITLE
Allow use of double quotes in imports

### DIFF
--- a/Reinforced.Typings/Ast/Dependency/RtImport.cs
+++ b/Reinforced.Typings/Ast/Dependency/RtImport.cs
@@ -15,10 +15,10 @@ namespace Reinforced.Typings.Ast.Dependency
         /// </summary>
         public string Target
         {
-            get { return _target; }
+            get => _target;
             set
             {
-                _target = value == null ? null : value.Trim();
+                _target = value?.Trim();
                 CheckWildcardImport();
             }
         }
@@ -26,7 +26,12 @@ namespace Reinforced.Typings.Ast.Dependency
         /// <summary>
         /// Gets flag whether RtImport is wildcard import
         /// </summary>
-        public bool IsWildcard { get { return WildcardAlias != null; } }
+        public bool IsWildcard => WildcardAlias != null;
+
+        /// <summary>
+        /// Use double quotes instead of single quotes
+        /// </summary>
+        public bool UseDoubleQuotes { get; set; }
 
         /// <summary>
         /// Gets wildcard alias of import
@@ -41,7 +46,6 @@ namespace Reinforced.Typings.Ast.Dependency
                 if (arr.Length < 2)
                 {
                     WildcardAlias = null;
-
                 }
                 else
                 {
@@ -65,7 +69,10 @@ namespace Reinforced.Typings.Ast.Dependency
         public bool IsRequire { get; set; }
 
         /// <inheritdoc />
-        public override IEnumerable<RtNode> Children { get { yield break; } }
+        public override IEnumerable<RtNode> Children
+        {
+            get { yield break; }
+        }
 
         /// <inheritdoc />
         public override void Accept(IRtVisitor visitor)
@@ -82,8 +89,11 @@ namespace Reinforced.Typings.Ast.Dependency
         /// <inheritdoc />
         public override string ToString()
         {
-            if (IsRequire) return string.Format("import {0} = require('{1}');", Target, From);
-            return string.Format("import {0} from '{1}';", Target, From);
+            var quote = UseDoubleQuotes ? "\"" : "'";
+
+            return IsRequire
+                ? $"import {Target} = require({quote}{From}{quote});"
+                : $"import {Target} from {quote}{From}{quote};";
         }
     }
 }

--- a/Reinforced.Typings/Fluent/ConfigurationBuilderExtensions.cs
+++ b/Reinforced.Typings/Fluent/ConfigurationBuilderExtensions.cs
@@ -42,9 +42,12 @@ namespace Reinforced.Typings.Fluent
         /// Please not the you do not have to specify quotes here! Quotes will be added automatically
         /// </param>
         /// <param name="isRequire">When true, import will be generated as "import ImportTarget = require('ImportSource')"</param>
-        public static ConfigurationBuilder AddImport(this ConfigurationBuilder conf, string target, string from, bool isRequire = false)
+        /// <param name="useDoubleQuotes">When true, import will use double quotes instead of single quotes"</param>
+        public static ConfigurationBuilder AddImport(this ConfigurationBuilder conf, string target, string from,
+            bool isRequire = false, bool useDoubleQuotes = false)
         {
-            conf.Imports.Add(new RtImport() { Target = target, From = from, IsRequire = isRequire });
+            conf.Imports.Add(new RtImport()
+            { Target = target, From = from, IsRequire = isRequire, UseDoubleQuotes = useDoubleQuotes });
             return conf;
         }
 

--- a/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.Dependencies.cs
+++ b/Reinforced.Typings/Visitors/TypeScript/TypeScriptExportVisitor.Dependencies.cs
@@ -1,5 +1,4 @@
 using Reinforced.Typings.Ast.Dependency;
-using Reinforced.Typings.Ast.TypeNames;
 
 #pragma warning disable 1591
 
@@ -9,6 +8,8 @@ namespace Reinforced.Typings.Visitors.TypeScript
     {
         public override void Visit(RtImport node)
         {
+            var quote = node.UseDoubleQuotes ? "\"" : "'";
+
             Write("import ");
             if (node.Target != null)
             {
@@ -16,23 +17,23 @@ namespace Reinforced.Typings.Visitors.TypeScript
                 Write(" ");
                 if (node.IsRequire)
                 {
-                    WriteLine(string.Format("= require('{0}');", node.From));
+                    WriteLine($"= require({quote}{node.From}{quote});");
                 }
                 else
                 {
-                    WriteLine(string.Format("from '{0}';", node.From));
+                    WriteLine($"from {quote}{node.From}{quote};");
                 }
             }
             else
             {
-                WriteLine(string.Format("'{0}';", node.From));
+                WriteLine($"{quote}{node.From}{quote};");
             }
-            
+
         }
 
         public override void Visit(RtReference node)
         {
-            WriteLine(string.Format("///<reference path=\"{0}\"/>", node.Path));
+            WriteLine($"///<reference path=\"{node.Path}\"/>");
         }
     }
 }


### PR DESCRIPTION
Resolves #269

Not sure if I missed anything as I'm new to this codebase.

It might be better to make the quotes option a global option rather than per import, but I'm not sure how to do that.