### PR TITLE
remove conditional error when disabling, treating warnings as errors

### DIFF
--- a/stuff/Reinforced.Typings.targets
+++ b/stuff/Reinforced.Typings.targets
@@ -28,15 +28,10 @@
 	<UsingTask TaskName="Reinforced.Typings.Integrate.RtCli" AssemblyFile="$(RtTargetsPath)\Reinforced.Typings.Integrate.dll" />
 	<UsingTask TaskName="Reinforced.Typings.Integrate.RemoveTypescriptStep" AssemblyFile="$(RtTargetsPath)\Reinforced.Typings.Integrate.dll" />
 	
-	<Target Name="ConditionallyDisableTypeScriptCompilation" Condition="'$(RtBypassTypeScriptcompilation)' == 'true'">
+	<Target Name="ConditionallyDisableTypeScriptCompilation" Condition="'$(RtBypassTypeScriptcompilation)' != 'false'">
 		<Warning 
 			File="Reinforced.Typings.settings.xml"
-			Text="TypeScript sources will not be built before project compile because it is disabled by Reinforced.Typings configuration"
-			Condition="'$(TreatWarningsAsErrors)' != 'true'"/>
-		<Error 
-			File="Reinforced.Typings.settings.xml"
-			Text="TypeScript sources will not be built before project compile because it is disabled by Reinforced.Typings configuration"
-			Condition="'$(TreatWarningsAsErrors)' == 'true'"/>
+			Text="TypeScript sources will not be built before project compile because it is disabled by Reinforced.Typings configuration"/>
 		<RemoveTypeScriptStep Original="$(CompileDependsOn)">
 			<Output PropertyName="CompileDependsOn" TaskParameter="Fixed"/>
 		</RemoveTypeScriptStep>

--- a/stuff/Reinforced.Typings.targets
+++ b/stuff/Reinforced.Typings.targets
@@ -50,12 +50,7 @@
 	<Target Name="ConditionallyShowDisabledWarning" Condition="'$(RtDisable)' != 'false'">
 		<Warning
 			File="Reinforced.Typings.settings.xml"
-			Text="Reinforced.Typings will not run because it is disabled in its configuration"
-			Condition="'$(TreatWarningsAsErrors)' != 'true'"/>
-		<Error
-			File="Reinforced.Typings.settings.xml"
-			Text="Reinforced.Typings will not run because it is disabled in its configuration"
-			Condition="'$(TreatWarningsAsErrors)' == 'true'"/>
+			Text="Reinforced.Typings will not run because it is disabled in its configuration"/>
 	</Target>
     <Target Name="ReinforcedTypingsGenerate" Condition="'$(BuildingProject)' != 'false' And '$(RtDisable)' == 'false'">	     
 		<RtCli 
@@ -74,7 +69,6 @@
 			ConfigurationMethod="$(RtConfigurationMethod)"
 			SuppressedWarnings="$(RtSuppress)"
 		/>
-		
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Properties="INeedThis=JustToRebuildTypescripts;BuildingProject=true" Targets="CompileTypeScript" Condition="'$(TypeScriptTarget)' != '' AND '@(ConfigFiles)' == ''" />
 		<MSBuild Projects="$(MSBuildProjectFullPath)" Properties="INeedThis=JustToRebuildTypescripts;BuildingProject=true" Targets="CompileTypeScriptWithTSConfig" Condition="'$(TypeScriptTarget)' != '' AND '@(ConfigFiles)' != ''" />
 	</Target>

--- a/stuff/Reinforced.Typings.targets
+++ b/stuff/Reinforced.Typings.targets
@@ -29,9 +29,8 @@
 	<UsingTask TaskName="Reinforced.Typings.Integrate.RemoveTypescriptStep" AssemblyFile="$(RtTargetsPath)\Reinforced.Typings.Integrate.dll" />
 	
 	<Target Name="ConditionallyDisableTypeScriptCompilation" Condition="'$(RtBypassTypeScriptcompilation)' != 'false'">
-		<Warning 
-			File="Reinforced.Typings.settings.xml"
-			Text="TypeScript sources will not be built before project compile because it is disabled by Reinforced.Typings configuration"/>
+		<Message 
+			Text="TypeScript sources will not be built before project compile because it is disabled in Reinforced.Typings.settings.xml or an overriding property setting."/>
 		<RemoveTypeScriptStep Original="$(CompileDependsOn)">
 			<Output PropertyName="CompileDependsOn" TaskParameter="Fixed"/>
 		</RemoveTypeScriptStep>
@@ -43,9 +42,8 @@
 		</RemoveTypeScriptStep>		
 	</Target>
 	<Target Name="ConditionallyShowDisabledWarning" Condition="'$(RtDisable)' != 'false'">
-		<Warning
-			File="Reinforced.Typings.settings.xml"
-			Text="Reinforced.Typings will not run because it is disabled in its configuration"/>
+		<Message
+			Text="Reinforced.Typings will not run because it is disabled in Reinforced.Typings.settings.xml or an overriding property setting."/>
 	</Target>
     <Target Name="ReinforcedTypingsGenerate" Condition="'$(BuildingProject)' != 'false' And '$(RtDisable)' == 'false'">	     
 		<RtCli 


### PR DESCRIPTION
Fixes #266, partially addresses #235

As someone who a) wants to disable mutation of source code on my build server, because it's a volatile thing that I don't want, and also b) wants to be conservative and treat my [unintentional] warnings as errors, I cannot do that because this always fails:
```
dotnet build --property:RtDisable=true --property:TreatWarningsAsErrors=true
```

The recommendation here is to simply decouple these properties and only `Message` when something is disabled as an intentional act.  

Also consider:

- Alternate `Warning` type with a unique error code for suppression, see #235.  I've opted for `Message` type in my recommendation.