### PR TITLE
Add DocumentationRemarks to the DocumentationMember 

### DIFF
--- a/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.RemarksDocs.cs
+++ b/Reinforced.Typings.Tests/SpecificCases/SpecificTestCases.RemarksDocs.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Threading.Tasks;
+using Reinforced.Typings.Fluent;
+using Xunit;
+
+namespace Reinforced.Typings.Tests.SpecificCases
+{
+    public partial class SpecificTestCases
+    {
+        /// <summary>
+        ///   dummy
+        /// </summary>
+        /// <remarks>
+        ///   Class remark.
+        /// </remarks>
+        public class SomeClassWithRemarks
+        {
+            /// <summary>
+            ///   dummy
+            /// </summary>
+            /// <remarks>
+            ///   Ctor remark.
+            /// </remarks>
+            public SomeClassWithRemarks() { }
+
+            /// <inheritdoc cref="SomeClassWithDocs"/>
+            /// <remarks>
+            ///   Property remark.
+            /// </remarks>
+            public string ClassProp { get; set; }
+
+            /// <inheritdoc cref="SomeClassWithDocs"/>
+            /// <remarks>
+            ///   Method remark.
+            /// </remarks>
+            public void Method() { }
+        }
+
+        [Fact]
+        public void RemarksParsedFromDocs()
+        {
+            const string result = @"
+module Reinforced.Typings.Tests.SpecificCases {
+	/** dummy */
+	export class SomeClassWithRemarks
+	{
+		/**
+		* @inheritdoc
+		*/
+		public ClassProp: string;
+		/**
+		* @inheritdoc
+		*/
+		public Method() : void { } 
+	}
+}";
+            AssertConfiguration(
+                s =>
+                {
+                    s.TryLookupDocumentationForAssembly(typeof(SpecificTestCases).Assembly);
+                    s.ExportAsClass<SomeClassWithRemarks>()
+                        .WithPublicProperties()
+                        .WithPublicMethods();
+                },
+                result,
+                expAction =>
+                {
+                    // Currently the <remarks /> are just parsed into the DocumentationMember
+                    // but not used in the generated typings. Hence we use the action on
+                    // the ExportContext to perform the actual test.
+                    // To avoid surprises like empty docs <remarks /> are currently only valid
+                    // if there is a <summar /> or <inheritdoc /> tag.
+
+                    var type = typeof(SomeClassWithRemarks);
+
+                    var classDoc = expAction.Context.Documentation.GetDocumentationMember(type);
+                    Assert.NotNull(classDoc);
+                    Assert.Equal("Class remark.", classDoc.Remarks.Text);
+
+                    var memberDoc = expAction.Context.Documentation.GetDocumentationMember(type.GetProperty(nameof(SomeClassWithRemarks.ClassProp)));
+                    Assert.NotNull(memberDoc);
+                    Assert.Equal("Property remark.", memberDoc.Remarks.Text);
+
+                    var methodeDoc = expAction.Context.Documentation.GetDocumentationMember(type.GetMethod(nameof(SomeClassWithRemarks.Method)));
+                    Assert.NotNull(methodeDoc);
+                    Assert.Equal("Method remark.", methodeDoc.Remarks.Text);
+
+                    var ctorRemark = expAction.Context.Documentation.GetDocumentationMember(type.GetConstructor(Array.Empty<Type>()));
+                    Assert.NotNull(ctorRemark);
+                    Assert.Equal("Ctor remark.", ctorRemark.Remarks.Text);
+                }
+            );
+        }
+    }
+}

--- a/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
+++ b/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
@@ -26,6 +26,11 @@
             return dm.Summary != null && !string.IsNullOrEmpty(dm.Summary.Text);
         }
 
+        public static bool HasRemarks(this DocumentationMember dm)
+        {
+            return dm.Remarks != null && !string.IsNullOrEmpty(dm.Remarks.Text);
+        }
+
         public static bool HasParameters(this DocumentationMember dm)
         {
             return dm.Parameters != null && dm.Parameters.Length > 0;

--- a/Reinforced.Typings/Xmldoc/Model/Model.cs
+++ b/Reinforced.Typings/Xmldoc/Model/Model.cs
@@ -39,6 +39,9 @@ namespace Reinforced.Typings.Xmldoc.Model
         [XmlElement(ElementName = "summary")]
         public DocumentationSummary Summary { get; set; }
 
+        [XmlElement(ElementName = "remarks")]
+        public DocumentationRemarks Remarks { get; set; }
+
         [XmlElement(ElementName = "inheritdoc")]
         public DocumentationInheritDoc InheritDoc { get; set; }
 
@@ -88,6 +91,21 @@ namespace Reinforced.Typings.Xmldoc.Model
         public override void ReadXml(XmlReader reader)
         {
             Cref = reader.GetAttribute("cref");
+            Text = reader.ReadInnerXml().Trim();
+        }
+    }
+
+    public class DocumentationRemarks : XmlIgnoreInner
+    {
+        public string Text { get; set; }
+
+        public override string ToString()
+        {
+            return Text;
+        }
+
+        public override void ReadXml(XmlReader reader)
+        {
             Text = reader.ReadInnerXml().Trim();
         }
     }


### PR DESCRIPTION
This PR adds the `DocumentationRemarks` type which stores the content from XmlDocs `<remarks />` section.

The behaviour of the emitted code is not changed:
 * `DocumentationMember.GetDocumentationMember` will return `null` if a member has only a ´<remarks />` section but no other XmlDoc related data
 * The text content from the `<remarks />` section is just stored in the `DocumentationMember` but not used in any provided code generator implementation.
 
 However, when writing a custom code generator, the content of the `<remarks />` section is now available.
 
 This fixes #290.