### PR TITLE
Fix typo in DocumentationMemberExtensions::MemberType

### DIFF
--- a/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
+++ b/Reinforced.Typings/Xmldoc/Model/DocumentationMemberExtensions.cs
@@ -2,7 +2,7 @@
 {
     internal static class DocumentationMemberExtensions
     {
-        public static DocumentationMemberType MeberType(this string name)
+        public static DocumentationMemberType MemberType(this string name)
         {
             if (string.IsNullOrEmpty(name)) return DocumentationMemberType.Unknown;
             if (name.Contains("#ctor")) return DocumentationMemberType.Constructor;

--- a/Reinforced.Typings/Xmldoc/Model/Model.cs
+++ b/Reinforced.Typings/Xmldoc/Model/Model.cs
@@ -29,7 +29,7 @@ namespace Reinforced.Typings.Xmldoc.Model
             set
             {
                 _name = value;
-                MemberType = _name.MeberType();
+                MemberType = _name.MemberType();
             }
         }
 


### PR DESCRIPTION
Pretty self-explanatory. Also a non-breaking change as only internal an internal type is affected.